### PR TITLE
chore: change the router-push for menu items to next/link

### DIFF
--- a/app/(app)/me/page.tsx
+++ b/app/(app)/me/page.tsx
@@ -5,12 +5,12 @@ import { PageContainer } from '@/components/layout/page-container';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useRouter } from 'next/navigation';
-import { Link } from 'next/link';
 import { ArrowRight, User, Settings, Shield, HelpCircle, LogOut, Eye, Clock, Lock, Smartphone } from 'lucide-react';
 import { useAuth } from '@/contexts/auth-context';
 import { useApiOpts } from '@/hooks/use-api';
 import * as userApi from '@/lib/api/user';
 import type { UserMe } from '@/types/api';
+import Link from 'next/link';
 
 const menuItems = [
   { section: 'Account', items: [{ title: 'Profile', icon: User, href: '/me/profile' }, { title: 'Settings', icon: Settings, href: '/me/settings' }, { title: 'Wallet', icon: Eye, href: '/me/settings/wallet' }] },
@@ -103,19 +103,17 @@ export default function MePage() {
                 {section.items.map((item) => {
                   const Icon = item.icon;
                   return (
-                    <Link key={item.href} href={item.href}>
-                      <button className="w-full text-left transition-colors active:bg-muted">
-                        <div className="rounded-lg border border-border bg-card p-4 flex items-center justify-between gap-3">
-                          <div className="flex items-center gap-3 flex-1 min-w-0">
-                            <Icon className="w-5 h-5 text-primary flex-shrink-0" />
-                            <span className="font-medium text-foreground text-sm truncate">{item.title}</span>
-                          </div>
-                          <div className="flex items-center gap-2 flex-shrink-0">
-                            {item.badge && <Badge variant="secondary" className="text-xs">{item.badge}</Badge>}
-                            <ArrowRight className="w-4 h-4 text-muted-foreground" />
-                          </div>
+                    <Link key={item.href} href={item.href} className="w-full text-left transition-colors active:bg-muted">
+                      <div className="rounded-lg border border-border bg-card p-4 flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-3 flex-1 min-w-0">
+                          <Icon className="w-5 h-5 text-primary flex-shrink-0" />
+                          <span className="font-medium text-foreground text-sm truncate">{item.title}</span>
                         </div>
-                      </button>
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          {item.badge && <Badge variant="secondary" className="text-xs">{item.badge}</Badge>}
+                          <ArrowRight className="w-4 h-4 text-muted-foreground" />
+                        </div>
+                      </div>
                     </Link>
                   );
                 })}


### PR DESCRIPTION
I changed the navigation of menuitems from router.push to next/link

this closes #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Menu items on the profile page now use native link navigation instead of programmatic button handling, improving semantics and accessibility while keeping the visible behavior and badges unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->