### PR TITLE
fix: add clipboard API fallback for non-HTTPS contexts (#17)

### DIFF
--- a/app/(app)/me/settings/receive/page.tsx
+++ b/app/(app)/me/settings/receive/page.tsx
@@ -33,14 +33,35 @@ export default function ReceivePage() {
   }, [opts.token]);
 
   const toCopy = payUri || alias;
+
+  const fallbackCopy = (text: string): boolean => {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      return document.execCommand('copy');
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  };
+
   const handleCopy = async () => {
     if (!toCopy) return;
     try {
-      await navigator.clipboard.writeText(toCopy);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(toCopy);
+      } else if (!fallbackCopy(toCopy)) {
+        throw new Error('Copy unsupported');
+      }
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      setError('Copy failed');
+      setError('Unable to copy — try selecting the address manually');
+      setTimeout(() => setError(''), 3000);
     }
   };
 


### PR DESCRIPTION
Closes #17

## Problem
`navigator.clipboard.writeText` is only available in secure (HTTPS) contexts. On HTTP origins, `navigator.clipboard` is `undefined`, causing an unhandled TypeError. The existing catch block also sets a vague "Copy failed" error that persists indefinitely.

## Changes
- Check `navigator.clipboard?.writeText` availability before calling it
- Add a legacy fallback using a hidden `<textarea>` + `document.execCommand('copy')` for non-HTTPS environments
- Improve the error message to guide the user ("Unable to copy — try selecting the address manually")
- Auto-clear the error after 3 seconds so it doesn't persist on screen

## File changed
- [app/(app)/me/settings/receive/page.tsx](cci:7://file:///c:/Users/HP/Desktop/wv3/app/%28app%29/me/settings/receive/page.tsx:0:0-0:0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copy functionality with enhanced browser compatibility to ensure address copying works across more browsers.
  * Enhanced error messaging when clipboard operations fail, with automatic dismissal after 3 seconds for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->