### PR TITLE
fix: consistent API error handling and UI improvements

### DIFF
--- a/app/(app)/lending/deposit/page.tsx
+++ b/app/(app)/lending/deposit/page.tsx
@@ -23,7 +23,9 @@ export default function LendingDepositPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setLender(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -55,8 +57,8 @@ export default function LendingDepositPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">Lender (Stellar address or ID)</label>
-              <Input value={lender} onChange={(e) => setLender(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or lender id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={lender} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Amount</label>

--- a/app/(app)/lending/withdraw/page.tsx
+++ b/app/(app)/lending/withdraw/page.tsx
@@ -23,7 +23,9 @@ export default function LendingWithdrawPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setLender(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -55,8 +57,8 @@ export default function LendingWithdrawPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">Lender (Stellar address or ID)</label>
-              <Input value={lender} onChange={(e) => setLender(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or lender id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={lender} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Amount</label>

--- a/app/(app)/savings/deposit/page.tsx
+++ b/app/(app)/savings/deposit/page.tsx
@@ -24,7 +24,9 @@ export default function SavingsDepositPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setUser(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -59,8 +61,8 @@ export default function SavingsDepositPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">User (Stellar address or ID)</label>
-              <Input value={user} onChange={(e) => setUser(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or user id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={user} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Amount</label>

--- a/app/(app)/savings/withdraw/page.tsx
+++ b/app/(app)/savings/withdraw/page.tsx
@@ -24,7 +24,9 @@ export default function SavingsWithdrawPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setUser(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -59,8 +61,8 @@ export default function SavingsWithdrawPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">User (Stellar address or ID)</label>
-              <Input value={user} onChange={(e) => setUser(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or user id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={user} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Term (seconds)</label>

--- a/app/(app)/send/page.tsx
+++ b/app/(app)/send/page.tsx
@@ -72,12 +72,13 @@ export default function SendPage() {
   const [loadingContacts, setLoadingContacts] = useState(true);
   const [submitError, setSubmitError] = useState('');
   const [sending, setSending] = useState(false);
+  const [loadError, setLoadError] = useState('');
 
   const loadTransfers = () => {
-    transfersApi.getTransfers(opts).then((data) => setTransfers(data.transfers ?? [])).catch(() => {}).finally(() => setLoadingTransfers(false));
+    transfersApi.getTransfers(opts).then((data) => setTransfers(data.transfers ?? [])).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load transfers')).finally(() => setLoadingTransfers(false));
   };
   const loadContacts = () => {
-    userApi.getContacts(opts).then((data) => setContacts(data.contacts ?? [])).catch(() => {}).finally(() => setLoadingContacts(false));
+    userApi.getContacts(opts).then((data) => setContacts(data.contacts ?? [])).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load contacts')).finally(() => setLoadingContacts(false));
   };
   useEffect(() => {
     loadTransfers();
@@ -142,6 +143,7 @@ export default function SendPage() {
       </header>
 
       <PageContainer>
+        {loadError && <p className="text-destructive text-sm mb-3">{loadError}</p>}
         <div className="rounded-lg border border-border bg-gradient-to-br from-primary to-secondary p-5 text-primary-foreground mb-5">
           <p className="text-sm font-medium opacity-90 mb-1">Available Balance</p>
           <p className="text-3xl font-bold">ACBU {formatAmount(BALANCE_PLACEHOLDER)}</p>

--- a/app/(public)/auth/signin/page.tsx
+++ b/app/(public)/auth/signin/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import React, { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -12,12 +12,20 @@ import * as authApi from '@/lib/api/auth';
 
 export default function SignInPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { login } = useAuth();
   const [identifier, setIdentifier] = useState('');
   const [passcode, setPasscode] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    if (searchParams.get('created') === '1') {
+      setSuccess('Account created successfully. Please sign in.');
+    }
+  }, [searchParams]);
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -69,15 +77,20 @@ export default function SignInPage() {
                 <p className="text-sm text-destructive">{error}</p>
               </div>
             )}
+            {success && (
+              <div className="flex gap-3 p-3 rounded-lg border border-green-500/30 bg-green-500/10">
+                <p className="text-sm text-green-600">{success}</p>
+              </div>
+            )}
 
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">
-                Username
+                Username, email, or phone
               </label>
               <Input
                 type="text"
                 autoComplete="username"
-                placeholder="Username"
+                placeholder="Username, email, or phone"
                 value={identifier}
                 onChange={(e) => setIdentifier(e.target.value)}
                 className="border-border"


### PR DESCRIPTION
## Summary
- Sign-in: show \`?created=1\` query param from signup as success message
- Sign-in: update label to 'Username, email, or phone' to reflect backend accepts all three
- Savings/Lending: make user field read-only to prevent users from withdrawing to wrong account
- Send page: show error messages when loading transfers/contacts fails

## Issues Fixed
Closes #42
Closes #41
Closes #33
Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added success confirmation message when account creation completes
  * Added error notifications for failed transfers and contacts loading on the send page

* **Bug Fixes**
  * Improved error handling across lending and savings operations with error logging

* **Improvements**
  * Made account identifier fields read-only in lending and savings pages
  * Updated sign-in field label to clarify accepted credential types (username, email, or phone)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->