### PR TITLE
fix: update sign-in label to include email and phone

### DIFF
--- a/app/(public)/auth/signin/page.tsx
+++ b/app/(public)/auth/signin/page.tsx
@@ -72,12 +72,12 @@ export default function SignInPage() {
 
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">
-                Username
+                Username, email, or phone
               </label>
               <Input
                 type="text"
                 autoComplete="username"
-                placeholder="Username"
+                placeholder="Username, email, or phone"
                 value={identifier}
                 onChange={(e) => setIdentifier(e.target.value)}
                 className="border-border"


### PR DESCRIPTION
## Summary
Label says "Username" but backend accepts username, email, or E.164 phone. Changed to "Username, email, or phone".

## Issues
Closes #41