### PR TITLE
fix: make user field read-only in savings/lending pages

### DIFF
--- a/app/(app)/lending/deposit/page.tsx
+++ b/app/(app)/lending/deposit/page.tsx
@@ -55,8 +55,8 @@ export default function LendingDepositPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">Lender (Stellar address or ID)</label>
-              <Input value={lender} onChange={(e) => setLender(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or lender id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={lender} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Amount</label>

--- a/app/(app)/lending/withdraw/page.tsx
+++ b/app/(app)/lending/withdraw/page.tsx
@@ -55,8 +55,8 @@ export default function LendingWithdrawPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">Lender (Stellar address or ID)</label>
-              <Input value={lender} onChange={(e) => setLender(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or lender id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={lender} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Amount</label>

--- a/app/(app)/savings/deposit/page.tsx
+++ b/app/(app)/savings/deposit/page.tsx
@@ -59,8 +59,8 @@ export default function SavingsDepositPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">User (Stellar address or ID)</label>
-              <Input value={user} onChange={(e) => setUser(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or user id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={user} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Amount</label>

--- a/app/(app)/savings/withdraw/page.tsx
+++ b/app/(app)/savings/withdraw/page.tsx
@@ -59,8 +59,8 @@ export default function SavingsWithdrawPage() {
           {success && <p className="text-green-600 text-sm">{success}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-foreground mb-2 block">User (Stellar address or ID)</label>
-              <Input value={user} onChange={(e) => setUser(e.target.value)} className="border-border font-mono text-sm" placeholder="G... or user id" />
+              <label className="text-sm font-medium text-foreground mb-2 block">Your account</label>
+              <Input value={user} readOnly className="border-border font-mono text-sm bg-muted" />
             </div>
             <div>
               <label className="text-sm font-medium text-foreground mb-2 block">Term (seconds)</label>


### PR DESCRIPTION
## Summary
Withdraw page pre-fills "User (Stellar address or ID)" from getReceive but leaves it editable; users could change it and withdraw to the wrong account. Made the field read-only to prevent this.

## Issues
Closes #33