### PR TITLE
fix: add consistent API error handling

### DIFF
--- a/app/(app)/lending/deposit/page.tsx
+++ b/app/(app)/lending/deposit/page.tsx
@@ -23,7 +23,9 @@ export default function LendingDepositPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setLender(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/app/(app)/lending/withdraw/page.tsx
+++ b/app/(app)/lending/withdraw/page.tsx
@@ -23,7 +23,9 @@ export default function LendingWithdrawPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setLender(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/app/(app)/savings/deposit/page.tsx
+++ b/app/(app)/savings/deposit/page.tsx
@@ -24,7 +24,9 @@ export default function SavingsDepositPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setUser(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/app/(app)/savings/withdraw/page.tsx
+++ b/app/(app)/savings/withdraw/page.tsx
@@ -24,7 +24,9 @@ export default function SavingsWithdrawPage() {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string' && uri.length >= 56) setUser(uri);
-    }).catch(() => {});
+    }).catch((e) => {
+      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/app/(app)/send/page.tsx
+++ b/app/(app)/send/page.tsx
@@ -72,12 +72,13 @@ export default function SendPage() {
   const [loadingContacts, setLoadingContacts] = useState(true);
   const [submitError, setSubmitError] = useState('');
   const [sending, setSending] = useState(false);
+  const [loadError, setLoadError] = useState('');
 
   const loadTransfers = () => {
-    transfersApi.getTransfers(opts).then((data) => setTransfers(data.transfers ?? [])).catch(() => {}).finally(() => setLoadingTransfers(false));
+    transfersApi.getTransfers(opts).then((data) => setTransfers(data.transfers ?? [])).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load transfers')).finally(() => setLoadingTransfers(false));
   };
   const loadContacts = () => {
-    userApi.getContacts(opts).then((data) => setContacts(data.contacts ?? [])).catch(() => {}).finally(() => setLoadingContacts(false));
+    userApi.getContacts(opts).then((data) => setContacts(data.contacts ?? [])).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load contacts')).finally(() => setLoadingContacts(false));
   };
   useEffect(() => {
     loadTransfers();
@@ -142,6 +143,7 @@ export default function SendPage() {
       </header>
 
       <PageContainer>
+        {loadError && <p className="text-destructive text-sm mb-3">{loadError}</p>}
         <div className="rounded-lg border border-border bg-gradient-to-br from-primary to-secondary p-5 text-primary-foreground mb-5">
           <p className="text-sm font-medium opacity-90 mb-1">Available Balance</p>
           <p className="text-3xl font-bold">ACBU {formatAmount(BALANCE_PLACEHOLDER)}</p>


### PR DESCRIPTION
## Summary
burn/page.tsx handles ApiError with status-specific messages; ensure all other API-calling pages use the same pattern.

- Send page: display error messages when loading transfers/contacts fails
- Savings/Lending pages: log errors to console when receive address load fails

## Issues
Closes #45