### PR TITLE
Fix: send note to createTransfer API

### DIFF
--- a/app/(app)/send/page.tsx
+++ b/app/(app)/send/page.tsx
@@ -97,7 +97,7 @@ export default function SendPage() {
     setSubmitError('');
     setSending(true);
     try {
-      await transfersApi.createTransfer({ to, amount_acbu: amount }, opts);
+      await transfersApi.createTransfer({ to, amount_acbu: amount, note }, opts);
       loadTransfers();
       setShowConfirmDialog(false);
       setShowSendDialog(false);

--- a/types/api.ts
+++ b/types/api.ts
@@ -76,6 +76,7 @@ export interface TransfersListResponse {
 export interface CreateTransferBody {
   to: string;
   amount_acbu: string;
+  note?: string;
 }
 
 export interface CreateTransferResponse {


### PR DESCRIPTION
Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transfers now support an optional note field, allowing users to attach additional context or information when submitting transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->