### PR TITLE
Add CSRF protection to state-changing API requests

### DIFF
--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -7,6 +7,12 @@ const BASE = typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE_
   ? process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, '')
   : '';
 
+function getCsrfToken(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const match = document.cookie.match(/(^|;\s*)XSRF-TOKEN=([^;]*)/);
+  return match ? decodeURIComponent(match[2]) : undefined;
+}
+
 export interface RequestOptions {
   token?: string | null;
   signal?: AbortSignal;
@@ -27,6 +33,10 @@ async function request<T>(
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
+  const csrfToken = getCsrfToken();
+  if (csrfToken) {
+    headers['X-XSRF-TOKEN'] = csrfToken;
+  }
   if (opts.token) {
     headers['Authorization'] = `Bearer ${opts.token}`;
   }


### PR DESCRIPTION
Closes #49

## Summary
- Added getCsrfToken function to read XSRF-TOKEN cookie from document
- Include X-XSRF-TOKEN header in all API requests when token is present
- This provides CSRF protection for state-changing operations (POST, PUT, DELETE)