### PR TITLE
fix: block negative values in send amount input (#71)

### DIFF
--- a/app/(app)/send/page.tsx
+++ b/app/(app)/send/page.tsx
@@ -235,7 +235,7 @@ export default function SendPage() {
               <Label className="text-foreground">Amount</Label>
               <div className="flex gap-2">
                 <span className="flex items-center text-muted-foreground font-medium">AFK</span>
-                <Input type="number" placeholder="0.00" value={amount} onChange={(e) => setAmount(e.target.value)} className="border-border text-lg font-semibold" />
+                <Input type="number" placeholder="0.00" min="0" value={amount} onChange={(e) => { const v = e.target.value; if (v === '' || parseFloat(v) >= 0) setAmount(v); }} onKeyDown={(e) => { if (e.key === '-' || e.key === 'e' || e.key === 'E') e.preventDefault(); }} className="border-border text-lg font-semibold" />
               </div>
               {exceedsBalance && <p className="text-xs text-destructive">Insufficient balance.</p>}
               <p className="text-xs text-muted-foreground">Available: AFK {formatAmount(BALANCE_PLACEHOLDER)}</p>


### PR DESCRIPTION
## Summary
  - Add `min="0"` to the amount input on the send page
  - Block `-`, `e`, and `E` keys via `onKeyDown` (all keyboard paths to negative/scientific notation)
  - Guard `onChange` to reject any pasted negative value

  Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced input validation for the amount field to prevent entry of negative amounts and exponential notation, ensuring users can only enter valid non-negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->