### PR TITLE
fix: display amount in success dialog after transfer

### DIFF
--- a/app/(app)/send/page.tsx
+++ b/app/(app)/send/page.tsx
@@ -102,13 +102,15 @@ export default function SendPage() {
       loadTransfers();
       setShowConfirmDialog(false);
       setShowSendDialog(false);
-      setShowSuccessDialog(true);
       setLastSentAmount(amount);
-      setAmount('');
-      setNote('');
-      setCustomRecipient('');
-      setSelectedContact(null);
-      setTimeout(() => setShowSuccessDialog(false), 2500);
+      setShowSuccessDialog(true);
+      setTimeout(() => {
+        setShowSuccessDialog(false);
+        setAmount('');
+        setNote('');
+        setCustomRecipient('');
+        setSelectedContact(null);
+      }, 2500);
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : 'Transfer failed');
     } finally {


### PR DESCRIPTION
Move form state clearing from before dialog shows to inside the setTimeout callback, so the amount value remains available while the success dialog is visible instead of showing empty.

Closes #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronized form reset and success dialog dismissal timing. After a successful transfer, the form fields now clear and the success message disappears simultaneously, providing a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->