### PR TITLE
fix: add aria-label to password toggle button in signin page

### DIFF
--- a/app/(public)/auth/signin/page.tsx
+++ b/app/(public)/auth/signin/page.tsx
@@ -115,6 +115,7 @@ export default function SignInPage() {
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
                   disabled={loading}
                 >
                   {showPassword ? (


### PR DESCRIPTION
Password toggle button lacked an aria-label, making it inaccessible to screen readers.

Added a dynamic aria-label ("Show password" / "Hide password") based on toggle state.

Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added screen reader support to the password visibility toggle, providing clear "Show password" and "Hide password" labels for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->