### PR TITLE
fix: point Two-Factor Auth link to settings page instead of auth flow

### DIFF
--- a/app/(app)/me/page.tsx
+++ b/app/(app)/me/page.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link';
 
 const menuItems = [
   { section: 'Account', items: [{ title: 'Profile', icon: User, href: '/me/profile' }, { title: 'Settings', icon: Settings, href: '/me/settings' }, { title: 'Wallet', icon: Eye, href: '/me/settings/wallet' }] },
-  { section: 'Security', items: [{ title: 'KYC Verification', icon: Shield, href: '/me/kyc', badge: 'Pending' }, { title: 'Two-Factor Auth', icon: Smartphone, href: '/auth/2fa' }, { title: 'Recovery Settings', icon: Lock, href: '/me/recovery' }] },
+  { section: 'Security', items: [{ title: 'KYC Verification', icon: Shield, href: '/me/kyc', badge: 'Pending' }, { title: 'Two-Factor Auth', icon: Smartphone, href: '/me/settings/security' }, { title: 'Recovery Settings', icon: Lock, href: '/me/recovery' }] },
   { section: 'Support', items: [{ title: 'Help & Support', icon: HelpCircle, href: '/me/help' }, { title: 'Activity History', icon: Clock, href: '/activity' }] },
 ];
 


### PR DESCRIPTION
## Summary

- Fix the "Two-Factor Auth" menu item in the profile page (`app/(app)/me/page.tsx`) to link to `/me/settings/security` instead of `/auth/2fa`
- `/auth/2fa` is the authentication flow (used during login), not a settings page — users clicking this from their profile would be incorrectly redirected to the auth flow
- `/me/settings/security` already exists as the security settings page where 2FA configuration belongs

## Test plan

- [ ] Navigate to the profile page (`/me`)
- [ ] Click the "Two-Factor Auth" menu item under the Security section
- [ ] Verify it navigates to `/me/settings/security` (not `/auth/2fa`)

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Two-Factor Auth security menu item to navigate to the correct settings location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->