### PR TITLE
fix: use stable currency key instead of array index in rate lists

### DIFF
--- a/app/(app)/mint/page.tsx
+++ b/app/(app)/mint/page.tsx
@@ -201,8 +201,8 @@ export default function MintPage() {
               {ratesLoading ? (
                 <div className="animate-pulse h-20 bg-muted rounded-lg" />
               ) : rates?.rates?.length ? (
-                rates.rates.map((r: { currency?: string; rate?: number }, i: number) => (
-                  <Card key={i} className="border-border p-4">
+                rates.rates.map((r: { currency?: string; rate?: number }) => (
+                  <Card key={r.currency ?? r.rate} className="border-border p-4">
                     <div className="flex justify-between">
                       <p className="font-semibold text-foreground">{r.currency ?? 'Rate'}</p>
                       <p className="text-lg font-bold text-primary">{r.rate != null ? String(r.rate) : '—'}</p>

--- a/app/(app)/rates/page.tsx
+++ b/app/(app)/rates/page.tsx
@@ -44,8 +44,8 @@ export default function RatesPage() {
           </div>
         ) : rates?.rates?.length ? (
           <div className="space-y-2">
-            {(rates.rates as Array<{ currency?: string; rate?: number }>).map((r, i) => (
-              <Card key={i} className="border-border p-4">
+            {(rates.rates as Array<{ currency?: string; rate?: number }>).map((r) => (
+              <Card key={r.currency ?? r.rate} className="border-border p-4">
                 <div className="flex justify-between items-center">
                   <p className="font-semibold text-foreground">{r.currency ?? 'Rate'}</p>
                   <p className="text-lg font-bold text-primary">{r.rate != null ? String(r.rate) : '—'}</p>


### PR DESCRIPTION
## Summary

- Replace array index (`i`) used as React `key` prop with `r.currency` (falling back to `r.rate`) in both `app/(app)/mint/page.tsx` and `app/(app)/rates/page.tsx`
- Using array indices as keys causes incorrect component reuse, stale state, and rendering bugs when lists are reordered or filtered
- `currency` is a stable, unique identifier from the `RatesResponse` API type

## Files changed

- `app/(app)/mint/page.tsx` — rates tab list: `key={i}` → `key={r.currency ?? r.rate}`
- `app/(app)/rates/page.tsx` — rates list: `key={i}` → `key={r.currency ?? r.rate}`

## Test plan

- [ ] Navigate to the Mint page, switch to the Rates tab — verify rates render correctly
- [ ] Navigate to the dedicated Rates page (`/rates`) — verify rates render correctly
- [ ] Confirm no React key warnings in the console

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced rates display stability by improving list reconciliation logic, ensuring smooth and consistent updates when rates data changes or reorders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->