### PR TITLE
fix: surface getReceive errors in savings page

### DIFF
--- a/app/(app)/savings/page.tsx
+++ b/app/(app)/savings/page.tsx
@@ -82,6 +82,7 @@ export default function SavingsPage() {
   const [apiUser, setApiUser] = useState('');
   const [positionsBalance, setPositionsBalance] = useState<string | number | null>(null);
   const [positionsLoading, setPositionsLoading] = useState(false);
+  const [receiveError, setReceiveError] = useState('');
   const [selectedAccount, setSelectedAccount] = useState<SavingsAccount | null>(
     null
   );
@@ -90,10 +91,13 @@ export default function SavingsPage() {
   const [showDepositDialog, setShowDepositDialog] = useState(false);
 
   useEffect(() => {
+    setReceiveError('');
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
       if (uri && typeof uri === 'string') setApiUser(uri);
-    }).catch(() => { });
+    }).catch((e) => {
+      setReceiveError(e instanceof Error ? e.message : 'Failed to load receive address');
+    });
   }, [opts.token]);
   useEffect(() => {
     if (!apiUser) return;
@@ -161,6 +165,9 @@ export default function SavingsPage() {
       {/* Main Content */}
       <PageContainer>
         <div className="space-y-6">
+          {receiveError && (
+            <p className="text-sm text-destructive">{receiveError}</p>
+          )}
           {/* Total Savings - driven by API */}
           <Card className="border-border bg-gradient-to-br from-green-500/10 to-green-600/10 p-5">
             <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
## Summary

- Fix silently swallowed `userApi.getReceive()` errors in `app/(app)/savings/page.tsx`
- The empty `.catch(() => { })` gave users no feedback when the receive address failed to load, which also silently prevented savings positions from loading (since positions depend on the receive address)
- Add `receiveError` state to capture and display the error message in the UI

## Changes

- `app/(app)/savings/page.tsx`:
  - Add `receiveError` state variable
  - Replace empty `.catch(() => { })` with `.catch((e) => { setReceiveError(...) })`
  - Clear error on re-fetch (`setReceiveError('')` at start of effect)
  - Display error message above the savings content when present

## Test plan

- [ ] Load the savings page with valid auth — verify no error shown, positions load normally
- [ ] Simulate a `getReceive` failure (e.g. expired token, network error) — verify the error message is displayed
- [ ] Verify the error clears on re-fetch (e.g. token refresh)

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility for receive address loading. The app now displays error messages when address retrieval fails, replacing previous silent error handling with user-friendly feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->