### PR TITLE
fix auth/session and hook issues (closes #15 #77 #53 #84)

### DIFF
--- a/app/(app)/me/kyc/page.tsx
+++ b/app/(app)/me/kyc/page.tsx
@@ -25,7 +25,7 @@ export default function KYCPage() {
     }).catch((e) => {
       setError(e instanceof Error ? e.message : 'Failed to load');
     }).finally(() => setLoading(false));
-  }, [opts.token]);
+  }, [opts]);
 
   const kycLevel: number = applications.some((a) => a.status === 'approved') ? 2 : applications.length > 0 ? 1 : 0;
   const maxLevel = 3;

--- a/app/(app)/send/page.tsx
+++ b/app/(app)/send/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -74,16 +74,16 @@ export default function SendPage() {
   const [sending, setSending] = useState(false);
   const [loadError, setLoadError] = useState('');
 
-  const loadTransfers = () => {
+  const loadTransfers = useCallback(() => {
     transfersApi.getTransfers(opts).then((data) => setTransfers(data.transfers ?? [])).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load transfers')).finally(() => setLoadingTransfers(false));
-  };
-  const loadContacts = () => {
+  }, [opts]);
+  const loadContacts = useCallback(() => {
     userApi.getContacts(opts).then((data) => setContacts(data.contacts ?? [])).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load contacts')).finally(() => setLoadingContacts(false));
-  };
+  }, [opts]);
   useEffect(() => {
     loadTransfers();
     loadContacts();
-  }, [opts.token]);
+  }, [loadTransfers, loadContacts]);
 
   const handleRecipientSelect = (contact: ContactItem) => {
     setSelectedContact(contact);
@@ -158,11 +158,11 @@ export default function SendPage() {
               <Button onClick={() => setShowSendDialog(true)} className="bg-primary text-primary-foreground hover:bg-primary/90 h-auto flex-col py-4">
                 <Plus className="mb-2 h-5 w-5" /><span>New Transfer</span>
               </Button>
-              <Link href="/me/settings/contacts">
-                <Button variant="outline" className="border-border hover:bg-muted h-auto flex-col py-4 bg-transparent w-full">
+              <Button asChild variant="outline" className="border-border hover:bg-muted h-auto flex-col py-4 bg-transparent w-full">
+                <Link href="/me/settings/contacts">
                   <Plus className="mb-2 h-5 w-5" /><span>Add Contact</span>
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </div>
             <div>
               <h3 className="mb-3 text-sm font-semibold text-foreground">Frequent Recipients</h3>

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -3,7 +3,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useState, useMemo } from 'react';
 import * as authApi from '@/lib/api/auth';
 
-const AUTH_STORAGE_KEY = 'acbu_api_key';
 const USER_ID_KEY = 'acbu_user_id';
 
 interface AuthState {
@@ -24,12 +23,12 @@ function getStoredAuth(): AuthState {
   if (typeof window === 'undefined') {
     return { apiKey: null, userId: null, isAuthenticated: false };
   }
-  const apiKey = sessionStorage.getItem(AUTH_STORAGE_KEY);
   const userId = sessionStorage.getItem(USER_ID_KEY);
   return {
-    apiKey,
+    // Keep API key in memory only; do not persist in browser storage.
+    apiKey: null,
     userId,
-    isAuthenticated: !!apiKey && !!userId,
+    isAuthenticated: false,
   };
 }
 
@@ -42,11 +41,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const setAuth = useCallback((apiKey: string | null, userId: string | null) => {
     if (typeof window !== 'undefined') {
-      if (apiKey && userId) {
-        sessionStorage.setItem(AUTH_STORAGE_KEY, apiKey);
+      if (userId) {
         sessionStorage.setItem(USER_ID_KEY, userId);
       } else {
-        sessionStorage.removeItem(AUTH_STORAGE_KEY);
         sessionStorage.removeItem(USER_ID_KEY);
       }
     }


### PR DESCRIPTION
## Summary
- stop persisting API keys in browser session storage and keep auth token in memory only
- fix invalid nested interactive markup by using `Button asChild` for the Add Contact action
- memoize send-page loaders and align `useEffect` dependencies in send and KYC pages

## Issue closure
Closes #15
Closes #77
Closes #53
Closes #84

## Test plan
- [ ] Sign in, refresh, and confirm API key is not in `sessionStorage`
- [ ] Verify Add Contact navigation works from Send page
- [ ] Verify Send page loads contacts and transfers normally
- [ ] Verify KYC applications load on `/me/kyc`
- [ ] Run `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data refetching behavior in KYC and Send pages to trigger correctly on dependencies.
  * Adjusted UI component structure for improved interaction flow.

* **Chores**
  * Removed authentication persistence; users will need to re-authenticate after refreshing the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->