### PR TITLE
fix(a11y): add aria-label to settings card buttons for screen readers…

### DIFF
--- a/app/(app)/me/settings/page.tsx
+++ b/app/(app)/me/settings/page.tsx
@@ -31,12 +31,21 @@ export default function SettingsPage() {
           {items.map((item) => {
             const Icon = item.icon;
             return (
-              <button key={item.href} onClick={() => router.push(item.href)} className="w-full text-left">
+              <button
+                key={item.href}
+                onClick={() => router.push(item.href)}
+                className="w-full text-left"
+                aria-label={`Go to ${item.title} settings - ${item.description}`}
+              >
                 <Card className="border-border p-4 flex items-center gap-3">
                   <Icon className="w-5 h-5 text-primary flex-shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-foreground truncate">{item.title}</p>
-                    <p className="text-xs text-muted-foreground truncate">{item.description}</p>
+                    <p className="font-medium text-foreground truncate">
+                      {item.title}
+                    </p>
+                    <p className="text-xs text-muted-foreground truncate">
+                      {item.description}
+                    </p>
                   </div>
                 </Card>
               </button>


### PR DESCRIPTION
Closes #65

## Summary
Added aria-label attributes to settings card buttons to improve accessibility for screen readers.

## Changes
- Added descriptive aria-labels to all settings card buttons in `app/(app)/me/settings/page.tsx`

## Result
- Buttons are now accessible to screen readers
- Improved overall accessibility (a11y compliance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced settings navigation buttons with improved accessibility labels for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->