### PR TITLE
Fix/reserves units

### DIFF
--- a/app/(app)/reserves/page.tsx
+++ b/app/(app)/reserves/page.tsx
@@ -16,6 +16,12 @@ export default function ReservesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
+  const formatReserveRatio = (value: ReservesResponse['reserve_ratio']) => {
+    if (value == null) return '';
+    if (typeof value === 'number') return `${value.toFixed(2)}×`;
+    return `${value}×`;
+  };
+
   useEffect(() => {
     let cancelled = false;
     reservesApi.getReserves(opts).then((res) => {
@@ -48,7 +54,10 @@ export default function ReservesPage() {
                   <span className="text-muted-foreground">Reserve ratio</span>
                   <span className="text-xs text-muted-foreground">Reserves ÷ liabilities (ratio, 1.0 means fully backed).</span>
                 </div>
-                <span className="font-medium">{data.reserve_ratio}</span>
+                <div className="flex flex-col items-end">
+                  <span className="font-medium">{formatReserveRatio(data.reserve_ratio)}</span>
+                  <span className="text-xs text-muted-foreground">ratio</span>
+                </div>
               </div>
             )}
             {data.health != null && (
@@ -57,7 +66,10 @@ export default function ReservesPage() {
                   <span className="text-muted-foreground">Health</span>
                   <span className="text-xs text-muted-foreground">Overall system status reported by the issuer.</span>
                 </div>
-                <span className="font-medium">{data.health}</span>
+                <div className="flex flex-col items-end">
+                  <span className="font-medium">{data.health}</span>
+                  <span className="text-xs text-muted-foreground">status</span>
+                </div>
               </div>
             )}
             {Object.keys(data).filter((k) => !['reserve_ratio', 'health'].includes(k)).length > 0 && (


### PR DESCRIPTION
Closes #81

---

Summary: Add unit labels for reserve_ratio and health on the reserves page.

Details:

reserve_ratio now shows a × suffix plus a “ratio” label.
health now includes a “status” label for clarity.
Testing:

pnpm lint (existing repo warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the reserves page display with improved formatting and layout for reserve ratio and health information
  * Updated spacing and restructured UI blocks for better readability and organization
  * Added descriptive labels and units to key metrics for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->