### PR TITLE
Fix: Activity links should route to transaction details instead of send

### DIFF
--- a/app/(app)/activity/page.tsx
+++ b/app/(app)/activity/page.tsx
@@ -56,7 +56,7 @@ export default function ActivityPage() {
         ) : (
           <div className="space-y-2">
             {transfers.map((t) => (
-              <Link key={t.transaction_id} href={`/send/${t.transaction_id}`} className="block">
+              <Link key={t.transaction_id} href={`/transactions/${t.transaction_id}`} className="block">
                 <Card className="border-border p-4 flex items-center justify-between gap-3">
                   <div className="flex-1 min-w-0">
                     <p className="font-medium text-foreground">Transfer</p>


### PR DESCRIPTION
## What this does
- Fixes incorrect routing in Activity page
- Links now point to `/transactions/{id}` instead of `/send/{id}`

## Why
- Activity items should open transaction details, not send flow

- closes: #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation routing for transfer items in the activity list to direct to the correct page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->