### PR TITLE
fix: remove strict uri length filter for savings deposit user field

### DIFF
--- a/app/(app)/savings/deposit/page.tsx
+++ b/app/(app)/savings/deposit/page.tsx
@@ -23,7 +23,7 @@ export default function SavingsDepositPage() {
   useEffect(() => {
     userApi.getReceive(opts).then((data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
-      if (uri && typeof uri === 'string' && uri.length >= 56) setUser(uri);
+      if (uri && typeof uri === 'string') setUser(uri);
     }).catch((e) => {
       console.error(e instanceof Error ? e.message : 'Failed to load receive address');
     });


### PR DESCRIPTION
CLoses #54 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the savings deposit page to more reliably display your account information. The "Your account" field now populates whenever valid account data is available, providing consistent visibility throughout the deposit process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->