### PR TITLE
send-detail-back-link-icon-only

### DIFF
--- a/app/(app)/send/[id]/page.tsx
+++ b/app/(app)/send/[id]/page.tsx
@@ -1,19 +1,22 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import Link from 'next/link';
-import { PageContainer } from '@/components/layout/page-container';
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft } from 'lucide-react';
-import { useParams } from 'next/navigation';
-import { useApiOpts } from '@/hooks/use-api';
-import * as transfersApi from '@/lib/api/transfers';
-import { formatAmount } from '@/lib/utils';
+import React, { useState, useEffect } from "react";
+import Link from "next/link";
+import { PageContainer } from "@/components/layout/page-container";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useApiOpts } from "@/hooks/use-api";
+import * as transfersApi from "@/lib/api/transfers";
+import { formatAmount } from "@/lib/utils";
 
 function formatDate(iso: string) {
-  return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
 }
 
 /**
@@ -25,7 +28,7 @@ export default function TransferDetailPage() {
   const opts = useApiOpts();
   const [data, setData] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
 
   useEffect(() => {
     if (!id) {
@@ -33,14 +36,21 @@ export default function TransferDetailPage() {
       return;
     }
     let cancelled = false;
-    transfersApi.getTransfer(id, opts).then((res) => {
-      if (!cancelled) setData(res);
-    }).catch((e) => {
-      if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load');
-    }).finally(() => {
-      if (!cancelled) setLoading(false);
-    });
-    return () => { cancelled = true; };
+    transfersApi
+      .getTransfer(id, opts)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((e) => {
+        if (!cancelled)
+          setError(e instanceof Error ? e.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [id, opts.token]);
 
   if (!id) {
@@ -48,11 +58,15 @@ export default function TransferDetailPage() {
       <>
         <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
           <div className="px-4 py-3 flex items-center gap-3">
-            <Link href="/send"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
+            <Link href="/send" aria-label="Back to transfers">
+              <ArrowLeft className="w-5 h-5 text-primary" />
+            </Link>
             <h1 className="text-lg font-bold text-foreground">Transfer</h1>
           </div>
         </div>
-        <PageContainer><p className="text-muted-foreground">Invalid transfer ID.</p></PageContainer>
+        <PageContainer>
+          <p className="text-muted-foreground">Invalid transfer ID.</p>
+        </PageContainer>
       </>
     );
   }
@@ -62,7 +76,9 @@ export default function TransferDetailPage() {
       <>
         <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
           <div className="px-4 py-3 flex items-center gap-3">
-            <Link href="/send"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
+            <Link href="/send" aria-label="Back to transfers">
+              <ArrowLeft className="w-5 h-5 text-primary" />
+            </Link>
             <h1 className="text-lg font-bold text-foreground">Transfer</h1>
           </div>
         </div>
@@ -78,26 +94,34 @@ export default function TransferDetailPage() {
       <>
         <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
           <div className="px-4 py-3 flex items-center gap-3">
-            <Link href="/send"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
+            <Link href="/send" aria-label="Back to transfers">
+              <ArrowLeft className="w-5 h-5 text-primary" />
+            </Link>
             <h1 className="text-lg font-bold text-foreground">Transfer</h1>
           </div>
         </div>
-        <PageContainer><p className="text-destructive">{error || 'Not found'}</p></PageContainer>
+        <PageContainer>
+          <p className="text-destructive">{error || "Not found"}</p>
+        </PageContainer>
       </>
     );
   }
 
-  const status = (data.status as string) ?? '—';
-  const createdAt = (data.created_at as string) ?? '';
-  const completedAt = (data.completed_at as string) ?? '';
-  const txHash = (data.blockchain_tx_hash as string) ?? '';
+  const status = (data.status as string) ?? "—";
+  const createdAt = (data.created_at as string) ?? "";
+  const completedAt = (data.completed_at as string) ?? "";
+  const txHash = (data.blockchain_tx_hash as string) ?? "";
 
   return (
     <>
       <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
         <div className="px-4 py-3 flex items-center gap-3">
-          <Link href="/send"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
-          <h1 className="text-lg font-bold text-foreground truncate">Transfer</h1>
+          <Link href="/send" aria-label="Back to transfers">
+            <ArrowLeft className="w-5 h-5 text-primary" />
+          </Link>
+          <h1 className="text-lg font-bold text-foreground truncate">
+            Transfer
+          </h1>
         </div>
       </div>
       <PageContainer>
@@ -108,7 +132,9 @@ export default function TransferDetailPage() {
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Amount</span>
-            <span className="font-semibold">AFK {formatAmount(data.amount_acbu as string)}</span>
+            <span className="font-semibold">
+              AFK {formatAmount(data.amount_acbu as string)}
+            </span>
           </div>
           {createdAt && (
             <div className="flex justify-between text-sm">
@@ -124,7 +150,9 @@ export default function TransferDetailPage() {
           )}
           {txHash && (
             <div className="pt-2 border-t border-border">
-              <p className="text-xs text-muted-foreground mb-1">Transaction hash</p>
+              <p className="text-xs text-muted-foreground mb-1">
+                Transaction hash
+              </p>
               <p className="text-xs font-mono break-all">{txHash}</p>
             </div>
           )}


### PR DESCRIPTION
## Summary

Adds `aria-label` to the icon-only back link in `app/(app)/send/[id]/page.tsx` to improve accessibility for screen reader users.

## Problem

The back button renders only an `ArrowLeft` icon with no visible text or `aria-label`, making it unreadable by assistive technologies.

## Changes

- Added `aria-label="Back to transfers"` to all four instances of the back `<Link>` in the page (invalid ID, loading, error, and main render states)

## Why

Icon-only links without labels fail basic accessibility standards (WCAG 2.1 — Success Criterion 2.4.6). Screen readers would announce this as an empty or meaningless link, making navigation difficult for visually impaired users.

## Testing

- [ ] Screen reader announces "Back to transfers" when focusing the back link
- [ ] Back link still navigates to `/send` correctly
- [ ] All four render states (invalid ID, loading, error, success) have the label

Closes #64 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for the back navigation button.

* **Style**
  * Updated code formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->