### PR TITLE
fix: display note in confirm dialog before transfer

### DIFF
--- a/app/(app)/send/page.tsx
+++ b/app/(app)/send/page.tsx
@@ -261,6 +261,7 @@ export default function SendPage() {
             <div className="rounded-lg border border-border bg-muted p-4"><p className="text-xs text-muted-foreground">To</p><p className="font-semibold text-foreground truncate">{selectedContact?.alias || selectedContact?.pay_uri || customRecipient || '—'}</p></div>
             <div className="flex items-center justify-center"><div className="rounded-full bg-secondary p-2"><ArrowRight className="h-5 w-5 text-secondary-foreground" /></div></div>
             <div className="rounded-lg border border-border bg-muted p-4"><p className="text-xs text-muted-foreground">Amount</p><p className="text-2xl font-bold text-foreground">AFK {formatAmount(amount)}</p><p className="mt-2 text-xs text-muted-foreground">Network Fee: Free</p></div>
+            {note && <div className="rounded-lg border border-border bg-muted p-4"><p className="text-xs text-muted-foreground">Note</p><p className="text-sm text-foreground break-words">{note}</p></div>}
           </div>
           <div className="flex gap-3">
             <AlertDialogCancel className="flex-1 border-border" disabled={sending}>Cancel</AlertDialogCancel>


### PR DESCRIPTION
# Issue #43 - Confirm Dialog Shows Note

## What Changed

Added note display to the transfer confirmation dialog in `app/(app)/send/page.tsx`.

**File Modified:** `app/(app)/send/page.tsx`

**Change:**  
Added conditional rendering of the note field in the AlertDialog before the action buttons:
```tsx
{note && <div className="rounded-lg border border-border bg-muted p-4"><p className="text-xs text-muted-foreground">Note</p><p className="text-sm text-foreground break-words">{note}</p></div>}
```

## Why

Users want to review the note message they entered before confirming a transfer. Currently the note is collected but not shown in the confirmation dialog, which can lead to accidental transfers with unintended messages.

## Details

- Note displays only when user has entered text
- Styled to match recipient and amount sections
- Handles long text with word wrapping
- No API changes or backend updates needed
- Fully backward compatible

## Testing

1. Go to Send Money page
2. Enter recipient & amount
3. Add text to "Note (Optional)" field
4. Click "Continue"
5. Verify note appears in confirmation dialog
6. Try sending without a note to confirm it doesn't appear

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transfer confirmation dialog now displays notes when provided, with text wrapping for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->