### PR TITLE
fix: replace hardcoded total savings with API balance (#79)

### DIFF
--- a/app/(app)/savings/page.tsx
+++ b/app/(app)/savings/page.tsx
@@ -239,15 +239,16 @@ export default function SavingsPage() {
               </h2>
               <PiggyBank className="w-5 h-5 text-green-600" />
             </div>
+            {/* AFTER */}
             <p className="text-3xl font-bold text-foreground mb-1">
-              AFK 2,500.00
+              {positionsLoading ? "—" : `AFK ${formatAmount(totalSavings)}`}
             </p>
             <p className="text-xs text-muted-foreground mb-3">
               Earning 8% APY interest
             </p>
             <div className="flex items-center gap-1 text-xs text-green-600 font-medium">
               <TrendingUp className="w-3 h-3" />
-              <span>+AFK 16.67 this month</span>
+            <span>+AFK {formatAmount((totalSavings * 0.08) / 12)} this month</span>
             </div>
           </Card>
 


### PR DESCRIPTION
## Fix: Replace hardcoded Total Savings with API balance

Closes #79

### Problem
The "Total Savings" card in `app/(app)/savings/page.tsx` displayed a hardcoded `AFK 2,500.00` alongside a real API-fetched balance, causing the UI to show mixed mock and live data.

### Changes
- Replaced hardcoded `AFK 2,500.00` with `totalSavings`, which is derived from the existing `savingsApi.getSavingsPositions` call
- Added loading state (`—`) while the API request is in flight
- Monthly interest estimate now calculated dynamically from real balance instead of hardcoded `16.67`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed savings overview card to display accurate AFK balance based on your actual savings accounts instead of placeholder values.
  * Monthly interest estimate now dynamically calculated from your total savings rather than showing a fixed amount.
  * Added loading indicator while savings data is being retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->