### PR TITLE
fix: add maxLength to contact inputs (#72)

### DIFF
--- a/app/(app)/me/settings/contacts/page.tsx
+++ b/app/(app)/me/settings/contacts/page.tsx
@@ -13,6 +13,9 @@ import { useApiOpts } from '@/hooks/use-api';
 import * as userApi from '@/lib/api/user';
 import type { ContactItem } from '@/types/api';
 
+const ALIAS_MAX_LENGTH = 64;
+const PAY_URI_MAX_LENGTH = 256;
+
 export default function ContactsPage() {
   const opts = useApiOpts();
   const [contacts, setContacts] = useState<ContactItem[]>([]);
@@ -89,8 +92,20 @@ export default function ContactsPage() {
       <PageContainer>
         {error && <p className="text-destructive text-sm mb-3">{error}</p>}
         <form onSubmit={handleAdd} className="space-y-2 mb-6">
-          <Input placeholder="Alias" value={addAlias} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAddAlias(e.target.value)} className="border-border" />
-          <Input placeholder="Pay URI or address" value={addPayUri} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAddPayUri(e.target.value)} className="border-border" />
+          <Input
+            placeholder="Alias"
+            value={addAlias}
+            maxLength={ALIAS_MAX_LENGTH}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAddAlias(e.target.value)}
+            className="border-border"
+          />
+          <Input
+            placeholder="Pay URI or address"
+            value={addPayUri}
+            maxLength={PAY_URI_MAX_LENGTH}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAddPayUri(e.target.value)}
+            className="border-border"
+          />
           <Button type="submit" disabled={adding || (!addAlias.trim() && !addPayUri.trim())}>Add contact</Button>
         </form>
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add explicit `maxLength` limits to the contacts alias and pay URI inputs
- keep the limits generous enough for normal aliases and Stellar pay URI/address values while preventing unbounded input

## Testing
- `npm run build` *(fails due pre-existing unrelated parse errors in `app/(app)/lending/page.tsx:725` and `app/(app)/send/page.tsx:203`)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input length constraints to the contacts settings form. Alias field is now limited to 64 characters and pay URI/address field to 256 characters, preventing users from entering excessively long values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->