### PR TITLE
fix: hide broken New Goal CTA

### DIFF
--- a/app/savings/page.tsx
+++ b/app/savings/page.tsx
@@ -265,9 +265,11 @@ export default function SavingsPage() {
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold text-foreground">Savings Goals</h3>
+              {/* TODO: Implement goal model and uncomment button
               <Button size="sm" variant="outline" className="h-7 border-border bg-transparent" onClick={() => setShowNewGoalDialog(true)}>
                 <Plus className="w-3 h-3 mr-1" /> New Goal
               </Button>
+              */}
             </div>
             {goals.map((goal) => {
               const progress = (goal.currentAmount / goal.targetAmount) * 100;


### PR DESCRIPTION
closes #187 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The "New Goal" button in the Savings Goals section has been temporarily disabled pending further implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->