### PR TITLE
Fix loading states and replace placeholder finance data

### DIFF
--- a/app/business/page.tsx
+++ b/app/business/page.tsx
@@ -10,6 +10,7 @@ import { ArrowRight, Briefcase, Users, PiggyBank, CreditCard, Settings, Zap } fr
 import { useApiOpts } from '@/hooks/use-api';
 import * as businessApi from '@/lib/api/business';
 import type { BusinessStatsResponse } from '@/lib/api/business';
+import { featureFlags } from '@/lib/features';
 
 const businessServices = [
   { id: 'sme', title: 'SME Services', description: 'Business accounts, transfers & statements', icon: Briefcase, badge: 'Pro', href: '/sme' },
@@ -28,6 +29,10 @@ export default function BusinessPage() {
   const opts = useApiOpts();
   const [stats, setStats] = useState<BusinessStatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const visibleBusinessServices = businessServices.filter((service) => {
+    if (service.id === 'gateway') return featureFlags.businessGateway;
+    return true;
+  });
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -72,7 +77,7 @@ export default function BusinessPage() {
         </div>
 
         <div className="space-y-3 mb-6">
-          {businessServices.map((service) => {
+          {visibleBusinessServices.map((service) => {
             const Icon = service.icon;
             return (
               <button key={service.id} onClick={() => router.push(service.href)} className="w-full text-left">

--- a/app/currency/page.tsx
+++ b/app/currency/page.tsx
@@ -22,6 +22,7 @@ import { useApiOpts } from "@/hooks/use-api";
 import * as mintApi from "@/lib/api/mint";
 import * as burnApi from "@/lib/api/burn";
 import type { MintResponse, BurnResponse } from "@/types/api";
+import { featureFlags } from "@/lib/features";
 
 /**
  * Currency management hub.
@@ -180,12 +181,14 @@ export default function CurrencyPage() {
             >
               Burn
             </TabsTrigger>
-            <TabsTrigger
-              value="international"
-              className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary"
-            >
-              International
-            </TabsTrigger>
+            {featureFlags.internationalTransfers && (
+              <TabsTrigger
+                value="international"
+                className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary"
+              >
+                International
+              </TabsTrigger>
+            )}
           </TabsList>
 
           {/* Mint Tab */}
@@ -397,6 +400,7 @@ export default function CurrencyPage() {
           </TabsContent>
 
           {/* International Tab */}
+          {featureFlags.internationalTransfers && (
           <TabsContent value="international" className="px-4 py-6 space-y-4">
             <div>
               <p className="text-sm text-muted-foreground mb-3">
@@ -533,6 +537,7 @@ export default function CurrencyPage() {
               </div>
             </div>
           </TabsContent>
+          )}
         </Tabs>
       </PageContainer>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import './globals.css'
 import { AuthGuard } from '@/components/layout/auth-guard';
 import { AppLayout } from '@/components/app-layout';
 import { WalletSetupModal } from '@/components/wallet-setup-modal';
+import { Toaster } from '@/components/ui/toaster';
 
 export const metadata: Metadata = {
   title: 'ACBU - P2P Transfers',
@@ -53,6 +54,7 @@ export default async function RootLayout({
               <AppLayout>{children}</AppLayout>
             </AuthGuard>
             <WalletSetupModal />
+            <Toaster />
             <Analytics />
           </AuthProvider>
         </ErrorBoundary>

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -10,7 +10,9 @@ import { useBalance } from '@/hooks/use-balance';
 import { useApiOpts } from '@/hooks/use-api';
 import { formatAmount } from '@/lib/utils';
 import * as userApi from '@/lib/api/user';
+import * as transactionsApi from '@/lib/api/transactions';
 import type { UserMe } from '@/types/api';
+import type { TransactionListItem } from '@/types/api';
 import Link from 'next/link';
 
 const menuItems = [
@@ -27,14 +29,53 @@ export default function MePage() {
   const { balance, loading: balanceLoading } = useBalance();
   const opts = useApiOpts();
   const [user, setUser] = useState<UserMe | null>(null);
+  const [monthlyNet, setMonthlyNet] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    userApi.getMe(opts).then((data) => {
-      if (!cancelled) setUser(data);
+    const now = new Date();
+    const currentMonth = now.getMonth();
+    const currentYear = now.getFullYear();
+
+    const getTransactionDelta = (transaction: TransactionListItem) => {
+      if (transaction.status !== 'completed') return 0;
+
+      if (transaction.type === 'mint') {
+        return Number(transaction.amount_acbu ?? 0);
+      }
+
+      if (transaction.type === 'burn') {
+        return -Number(transaction.acbu_amount_burned ?? transaction.amount_acbu ?? 0);
+      }
+
+      if (transaction.type === 'transfer') {
+        return -Number(transaction.amount_acbu ?? 0);
+      }
+
+      return 0;
+    };
+
+    Promise.all([
+      userApi.getMe(opts),
+      transactionsApi.listTransactions({ limit: 100 }, opts),
+    ]).then(([userData, transactionsData]) => {
+      if (cancelled) return;
+
+      const currentMonthTransactions = (transactionsData.transactions ?? []).filter((transaction) => {
+        const createdAt = new Date(transaction.created_at);
+        return createdAt.getMonth() === currentMonth && createdAt.getFullYear() === currentYear;
+      });
+
+      const monthlyAggregate = currentMonthTransactions.reduce(
+        (sum, transaction) => sum + getTransactionDelta(transaction),
+        0,
+      );
+
+      setUser(userData);
+      setMonthlyNet(monthlyAggregate);
     }).catch((e) => {
       if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load profile');
     }).finally(() => {
@@ -71,6 +112,7 @@ export default function MePage() {
 
   const displayName = user?.username || user?.email || user?.phone_e164 || 'Account';
   const initials = (displayName.slice(0, 2) || 'AB').toUpperCase();
+  const monthlyNetPositive = (monthlyNet ?? 0) >= 0;
 
   return (
     <>
@@ -97,8 +139,8 @@ export default function MePage() {
             </div>
             <div className="rounded-lg border border-border bg-card p-4 text-center">
               <p className="text-xs text-muted-foreground mb-2 font-medium">This Month</p>
-              <p className="text-2xl font-bold text-accent">
-                {balanceLoading ? '...' : `+ACBU ${formatAmount(0)}`}
+              <p className={`text-2xl font-bold ${monthlyNetPositive ? 'text-accent' : 'text-destructive'}`}>
+                {loading ? '...' : monthlyNet === null ? '—' : `${monthlyNetPositive ? '+' : '-'}ACBU ${formatAmount(Math.abs(monthlyNet))}`}
               </p>
             </div>
           </div>

--- a/app/mint/page.tsx
+++ b/app/mint/page.tsx
@@ -28,10 +28,8 @@ import { submitBurnRedeemSingleClient } from '@/lib/stellar/burning';
 import { Keypair } from '@stellar/stellar-sdk';
 import * as ratesApi from '@/lib/api/rates';
 import * as fiatApi from '@/lib/api/fiat';
-import type { RatesResponse } from '@/types/api';
+import type { QuoteResponse, RatesResponse } from '@/types/api';
 import { formatAmount } from '@/lib/utils';
-const MINT_NETWORK_FEE_TEXT = "Estimated at confirmation";
-const BURN_PROCESSING_FEE_TEXT = "Estimated at confirmation";
 
 /** `acbu_*` from API = local currency units per 1 ACBU → ACBU = fiat / localPerAcbu. */
 function estimateAcbuFromFiat(
@@ -48,6 +46,48 @@ function estimateAcbuFromFiat(
   const localPerAcbu = parseFloat(String(raw));
   if (!(localPerAcbu > 0)) return null;
   return n / localPerAcbu;
+}
+
+function getNumericValue(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.trim()) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+}
+
+function getQuoteFee(quote: QuoteResponse | null): number | null {
+    if (!quote) return null;
+
+    return (
+        getNumericValue(quote.network_fee) ??
+        getNumericValue(quote.processing_fee) ??
+        getNumericValue(quote.fee_amount) ??
+        getNumericValue(quote.fee) ??
+        getNumericValue(quote.total_fee)
+    );
+}
+
+function getQuoteReceiveAmount(quote: QuoteResponse | null): number | null {
+    if (!quote) return null;
+
+    return (
+        getNumericValue(quote.receive_amount) ??
+        getNumericValue(quote.payout_amount) ??
+        getNumericValue(quote.local_amount) ??
+        getNumericValue(quote.amount)
+    );
+}
+
+function formatQuotedFee(
+    quote: QuoteResponse | null,
+    currency: string,
+    fallback: string,
+): string {
+    const fee = getQuoteFee(quote);
+    if (fee === null) return fallback;
+    return `${currency} ${formatAmount(fee)}`;
 }
 
 /**
@@ -72,6 +112,8 @@ export default function MintPage() {
   const [fiatAmount, setFiatAmount] = useState('');
   const [mintQuoteRates, setMintQuoteRates] = useState<RatesResponse | null>(null);
   const [mintAcbuReceived, setMintAcbuReceived] = useState<number | null>(null);
+    const [mintQuote, setMintQuote] = useState<QuoteResponse | null>(null);
+    const [burnQuote, setBurnQuote] = useState<QuoteResponse | null>(null);
   const rateRows = Array.isArray((rates as { rates?: Array<{ currency?: string; rate?: number }> } | null)?.rates)
     ? ((rates as { rates?: Array<{ currency?: string; rate?: number }> }).rates ?? [])
     : [];
@@ -95,6 +137,48 @@ export default function MintPage() {
       cancelled = true;
     };
   }, [opts.token]);
+
+    useEffect(() => {
+        if (!fiatAmount || parseFloat(fiatAmount) <= 0 || !selectedFiatCurrency) {
+            setMintQuote(null);
+            return;
+        }
+
+        let cancelled = false;
+        ratesApi
+            .getQuote(fiatAmount, selectedFiatCurrency, opts)
+            .then((quote) => {
+                if (!cancelled) setMintQuote(quote);
+            })
+            .catch(() => {
+                if (!cancelled) setMintQuote(null);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [fiatAmount, selectedFiatCurrency, opts]);
+
+    useEffect(() => {
+        if (!burnAmount || parseFloat(burnAmount) <= 0 || !selectedFiatCurrency) {
+            setBurnQuote(null);
+            return;
+        }
+
+        let cancelled = false;
+        ratesApi
+            .getQuote(burnAmount, selectedFiatCurrency, opts)
+            .then((quote) => {
+                if (!cancelled) setBurnQuote(quote);
+            })
+            .catch(() => {
+                if (!cancelled) setBurnQuote(null);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [burnAmount, selectedFiatCurrency, opts]);
 
   useEffect(() => {
     fiatApi
@@ -322,6 +406,18 @@ export default function MintPage() {
         setMintAcbuReceived(null);
     };
 
+    const mintFeeText = formatQuotedFee(
+        mintQuote,
+        mintQuote?.currency || selectedFiatCurrency || 'FIAT',
+        'Unavailable until quote loads',
+    );
+    const burnFeeText = formatQuotedFee(
+        burnQuote,
+        burnQuote?.currency || selectedFiatCurrency || 'FIAT',
+        'Unavailable until quote loads',
+    );
+    const quotedBurnReceiveAmount = getQuoteReceiveAmount(burnQuote);
+
   return (
     <>
       <header className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
@@ -457,7 +553,7 @@ export default function MintPage() {
                                         Network Fee
                                     </span>
                                     <span className="font-medium text-foreground">
-                                        {MINT_NETWORK_FEE_TEXT}
+                                        {mintFeeText}
                                     </span>
                                 </div>
                             </Card>
@@ -544,8 +640,8 @@ export default function MintPage() {
                                         You'll receive
                                     </span>
                                     <span className="font-medium text-foreground">
-                                        {burnAmount && selectedFiatCurrency
-                                            ? `~ ${selectedFiatCurrency} (based on current rate)`
+                                        {quotedBurnReceiveAmount !== null && selectedFiatCurrency
+                                            ? `~ ${selectedFiatCurrency} ${formatAmount(quotedBurnReceiveAmount)}`
                                             : "—"}
                                     </span>
                                 </div>
@@ -554,7 +650,7 @@ export default function MintPage() {
                                         Processing Fee
                                     </span>
                                     <span className="font-medium text-foreground">
-                                        {BURN_PROCESSING_FEE_TEXT}
+                                        {burnFeeText}
                                     </span>
                                 </div>
                             </Card>

--- a/app/send/page.tsx
+++ b/app/send/page.tsx
@@ -47,6 +47,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
 function formatDate(iso: string) {
   const d = new Date(iso);
   const today = new Date();
@@ -64,6 +65,7 @@ export default function SendPage() {
   const opts = useApiOpts();
   const { userId, stellarAddress } = useAuth();
   const kit = useStellarWalletsKit();
+  const { toast } = useToast();
   const { balance, loading: balanceLoading, refresh: refreshBalance } = useBalance();
   const [activeTab, setActiveTab] = useState("send");
   const [showSendDialog, setShowSendDialog] = useState(false);
@@ -81,25 +83,44 @@ export default function SendPage() {
   const [contacts, setContacts] = useState<ContactItem[]>([]);
   const [loadingTransfers, setLoadingTransfers] = useState(true);
   const [loadingContacts, setLoadingContacts] = useState(true);
+  const [transfersError, setTransfersError] = useState("");
+  const [contactsError, setContactsError] = useState("");
   const [submitError, setSubmitError] = useState("");
   const [sending, setSending] = useState(false);
-  const [loadError, setLoadError] = useState("");
 
   const loadTransfers = useCallback(() => {
-    setLoadError("");
+    setLoadingTransfers(true);
+    setTransfersError("");
     transfersApi.getTransfers(opts).then((data) => {
       setTransfers(data.transfers ?? []);
-      setLoadError("");
-    }).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load transfers')).finally(() => setLoadingTransfers(false));
-  }, [opts]);
+      setTransfersError("");
+    }).catch((e) => {
+      const message = e instanceof Error ? e.message : "Failed to load transfers";
+      setTransfersError(message);
+      toast({
+        title: "Could not load transfers",
+        description: message,
+        variant: "destructive",
+      });
+    }).finally(() => setLoadingTransfers(false));
+  }, [opts, toast]);
 
   const loadContacts = useCallback(() => {
-    setLoadError("");
+    setLoadingContacts(true);
+    setContactsError("");
     userApi.getContacts(opts).then((data) => {
       setContacts(data.contacts ?? []);
-      setLoadError("");
-    }).catch((e) => setLoadError(e instanceof Error ? e.message : 'Failed to load contacts')).finally(() => setLoadingContacts(false));
-  }, [opts]);
+      setContactsError("");
+    }).catch((e) => {
+      const message = e instanceof Error ? e.message : "Failed to load contacts";
+      setContactsError(message);
+      toast({
+        title: "Could not load contacts",
+        description: message,
+        variant: "destructive",
+      });
+    }).finally(() => setLoadingContacts(false));
+  }, [opts, toast]);
 
   useEffect(() => {
     loadTransfers();
@@ -242,10 +263,15 @@ const getStatusColor = (status: string) => {
                 </div>
             </header>
         <div className="px-4 py-4">
-          {loadError && (
+                  {(transfersError || contactsError) && (
             <div className="mb-6 flex items-center gap-2 rounded-xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive animate-in fade-in slide-in-from-top-2 duration-300">
               <AlertCircle className="h-5 w-5 shrink-0" />
-              <p className="font-medium">{loadError}</p>
+                      <div className="flex-1">
+                        <p className="font-medium">Some send data could not be loaded.</p>
+                        <p className="text-xs text-destructive/80">
+                          Retry the affected section to continue.
+                        </p>
+                      </div>
             </div>
           )}
 
@@ -270,6 +296,18 @@ const getStatusColor = (status: string) => {
               </h3>
               {loadingTransfers ? (
                 <SkeletonList count={2} itemHeight="h-14" />
+              ) : transfersError ? (
+                <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+                  <p className="font-medium">{transfersError}</p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="mt-3 border-destructive/30 text-destructive hover:bg-destructive/10"
+                    onClick={loadTransfers}
+                  >
+                    Retry transfers
+                  </Button>
+                </div>
               ) : transfers.length === 0 ? (
                 <div className="rounded-lg border border-border bg-card p-6 text-center">
                   <p className="text-sm text-muted-foreground">
@@ -334,24 +372,40 @@ const getStatusColor = (status: string) => {
                   <TabsTrigger value="custom">New Address</TabsTrigger>
                 </TabsList>
                 <TabsContent value="contact" className="mt-3">
-                  <Select
-                    value={selectedContact?.id || ""}
-                    onValueChange={(id: string) => {
-                      const c = contacts.find((x: ContactItem) => x.id === id);
-                      if (c) setSelectedContact(c);
-                    }}
-                  >
-                    <SelectTrigger className="border-border">
-                      <SelectValue placeholder="Select a contact" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {contacts.map((c: ContactItem) => (
-                        <SelectItem key={c.id} value={c.id}>
-                          {c.alias ?? c.pay_uri ?? c.id}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  {loadingContacts ? (
+                    <SkeletonList count={1} itemHeight="h-10" />
+                  ) : contactsError ? (
+                    <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
+                      <p className="font-medium">{contactsError}</p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="mt-3 border-destructive/30 text-destructive hover:bg-destructive/10"
+                        onClick={loadContacts}
+                      >
+                        Retry contacts
+                      </Button>
+                    </div>
+                  ) : (
+                    <Select
+                      value={selectedContact?.id || ""}
+                      onValueChange={(id: string) => {
+                        const c = contacts.find((x: ContactItem) => x.id === id);
+                        if (c) setSelectedContact(c);
+                      }}
+                    >
+                      <SelectTrigger className="border-border">
+                        <SelectValue placeholder="Select a contact" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {contacts.map((c: ContactItem) => (
+                          <SelectItem key={c.id} value={c.id}>
+                            {c.alias ?? c.pay_uri ?? c.id}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
                 </TabsContent>
                 <TabsContent value="custom">
                   <Input

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -1,0 +1,4 @@
+export const featureFlags = {
+  internationalTransfers: false,
+  businessGateway: false,
+} as const;

--- a/types/api.ts
+++ b/types/api.ts
@@ -217,6 +217,14 @@ export interface QuoteResponse {
   amount?: number;
   currency?: string;
   acbu_amount?: string;
+  fee?: string | number;
+  fee_amount?: string | number;
+  total_fee?: string | number;
+  network_fee?: string | number;
+  processing_fee?: string | number;
+  local_amount?: string | number;
+  receive_amount?: string | number;
+  payout_amount?: string | number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
This PR fixes four assigned frontend issues by replacing misleading placeholder behavior with backend-driven or explicitly gated UI.

## What changed
- surface send-page load failures with destructive toasts, inline error states, and retry actions for transfers and contacts
- replace the Me page `This Month` placeholder with a monthly aggregate derived from backend transactions
- remove hardcoded mint and burn fee placeholders by reading fee data from the backend quote response when available
- hide unfinished gateway and international UI behind centralized feature flags so navigation only exposes shipped features
- mount the existing toast system globally so load failures are visible to users

## Validation
- `get_errors` reports no file-level errors on the touched files
- attempted repo lint via `pnpm lint`, but `pnpm` is not installed in this environment
- attempted repo lint via `npm run lint`, but local dependencies are not installed, so `eslint` was unavailable

## Notes
- No `CONTRIBUTING.md` file was present in this checkout
- No local `.github/workflows` directory was present, so I validated against the repo scripts available in the clone

Closes #209
Closes #201
Closes #199
Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added feature flags to conditionally display services on Business and Currency pages.
  * Introduced toast notifications for user feedback across the app.
  * Added real-time quote-based fee and receive amount calculations for mint and burn operations.
  * Implemented monthly transaction tracking with dynamic net ACBU display on the profile page.
  * Enhanced error handling with dedicated error states and retry options on the Send page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->