### PR TITLE
feat: plumb transfer note through to receipts

### DIFF
--- a/app/send/[id]/page.tsx
+++ b/app/send/[id]/page.tsx
@@ -112,6 +112,7 @@ export default function TransferDetailPage() {
   const createdAt = (data.created_at as string) ?? "";
   const completedAt = (data.completed_at as string) ?? "";
   const txHash = (data.blockchain_tx_hash as string) ?? "";
+  const note = (data.note as string) ?? "";
   const localCurrency = (data.local_currency as string) ?? "";
   const localAmount = (data.local_amount as string) ?? "";
   const amountAcbu = (data.amount_acbu as string) ?? "";
@@ -153,6 +154,12 @@ export default function TransferDetailPage() {
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Completed</span>
               <span>{formatDate(completedAt)}</span>
+            </div>
+          )}
+          {note && (
+            <div className="pt-2 border-t border-border">
+              <p className="text-xs text-muted-foreground mb-1">Note</p>
+              <p className="text-sm text-foreground break-words">{note}</p>
             </div>
           )}
           {txHash && (

--- a/app/transactions/[id]/page.tsx
+++ b/app/transactions/[id]/page.tsx
@@ -1,20 +1,23 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import Link from 'next/link';
-import { PageContainer } from '@/components/layout/page-container';
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft } from 'lucide-react';
-import { useParams } from 'next/navigation';
-import { useApiOpts } from '@/hooks/use-api';
-import * as transactionsApi from '@/lib/api/transactions';
-import type { TransactionDetail } from '@/types/api';
-import { formatAmount } from '@/lib/utils';
+import React, { useState, useEffect } from "react";
+import Link from "next/link";
+import { PageContainer } from "@/components/layout/page-container";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useApiOpts } from "@/hooks/use-api";
+import * as transactionsApi from "@/lib/api/transactions";
+import type { TransactionDetail } from "@/types/api";
+import { formatAmount } from "@/lib/utils";
 
 function formatDate(iso: string) {
-  return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
 }
 
 /**
@@ -26,7 +29,7 @@ export default function TransactionDetailPage() {
   const opts = useApiOpts();
   const [data, setData] = useState<TransactionDetail | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
 
   useEffect(() => {
     if (!id) {
@@ -34,14 +37,21 @@ export default function TransactionDetailPage() {
       return;
     }
     let cancelled = false;
-    transactionsApi.getTransaction(id, opts).then((res) => {
-      if (!cancelled) setData(res);
-    }).catch((e) => {
-      if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load');
-    }).finally(() => {
-      if (!cancelled) setLoading(false);
-    });
-    return () => { cancelled = true; };
+    transactionsApi
+      .getTransaction(id, opts)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((e) => {
+        if (!cancelled)
+          setError(e instanceof Error ? e.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [id, opts.token]);
 
   if (!id) {
@@ -49,11 +59,15 @@ export default function TransactionDetailPage() {
       <>
         <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
           <div className="px-4 py-3 flex items-center gap-3">
-            <Link href="/activity"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
+            <Link href="/activity">
+              <ArrowLeft className="w-5 h-5 text-primary" />
+            </Link>
             <h1 className="text-lg font-bold text-foreground">Transaction</h1>
           </div>
         </div>
-        <PageContainer><p className="text-muted-foreground">Invalid transaction ID.</p></PageContainer>
+        <PageContainer>
+          <p className="text-muted-foreground">Invalid transaction ID.</p>
+        </PageContainer>
       </>
     );
   }
@@ -63,7 +77,9 @@ export default function TransactionDetailPage() {
       <>
         <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
           <div className="px-4 py-3 flex items-center gap-3">
-            <Link href="/activity"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
+            <Link href="/activity">
+              <ArrowLeft className="w-5 h-5 text-primary" />
+            </Link>
             <h1 className="text-lg font-bold text-foreground">Transaction</h1>
           </div>
         </div>
@@ -79,25 +95,33 @@ export default function TransactionDetailPage() {
       <>
         <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
           <div className="px-4 py-3 flex items-center gap-3">
-            <Link href="/activity"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
+            <Link href="/activity">
+              <ArrowLeft className="w-5 h-5 text-primary" />
+            </Link>
             <h1 className="text-lg font-bold text-foreground">Transaction</h1>
           </div>
         </div>
-        <PageContainer><p className="text-destructive">{error || 'Not found'}</p></PageContainer>
+        <PageContainer>
+          <p className="text-destructive">{error || "Not found"}</p>
+        </PageContainer>
       </>
     );
   }
 
-  const type = data.type ?? '—';
-  const status = data.status ?? '—';
-  const isFiat = type === 'mint' && data.currency && data.local_amount != null;
+  const type = data.type ?? "—";
+  const status = data.status ?? "—";
+  const isFiat = type === "mint" && data.currency && data.local_amount != null;
 
   return (
     <>
       <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
         <div className="px-4 py-3 flex items-center gap-3">
-          <Link href="/activity"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
-          <h1 className="text-lg font-bold text-foreground truncate">Transaction</h1>
+          <Link href="/activity">
+            <ArrowLeft className="w-5 h-5 text-primary" />
+          </Link>
+          <h1 className="text-lg font-bold text-foreground truncate">
+            Transaction
+          </h1>
         </div>
       </div>
       <PageContainer>
@@ -120,7 +144,9 @@ export default function TransactionDetailPage() {
           ) : data.amount_acbu != null ? (
             <div className="flex justify-between">
               <span className="text-muted-foreground">Amount</span>
-              <span className="font-semibold">ACBU {formatAmount(data.amount_acbu)}</span>
+              <span className="font-semibold">
+                ACBU {formatAmount(data.amount_acbu)}
+              </span>
             </div>
           ) : null}
           {data.usdc_amount != null && (
@@ -141,10 +167,20 @@ export default function TransactionDetailPage() {
               <span>{formatDate(data.completed_at)}</span>
             </div>
           )}
+          {data.note && (
+            <div className="pt-2 border-t border-border">
+              <p className="text-xs text-muted-foreground mb-1">Note</p>
+              <p className="text-sm text-foreground break-words">{data.note}</p>
+            </div>
+          )}
           {data.blockchain_tx_hash && (
             <div className="pt-2 border-t border-border">
-              <p className="text-xs text-muted-foreground mb-1">Transaction hash</p>
-              <p className="text-xs font-mono break-all">{data.blockchain_tx_hash}</p>
+              <p className="text-xs text-muted-foreground mb-1">
+                Transaction hash
+              </p>
+              <p className="text-xs font-mono break-all">
+                {data.blockchain_tx_hash}
+              </p>
             </div>
           )}
         </Card>

--- a/types/api.ts
+++ b/types/api.ts
@@ -4,7 +4,7 @@
 
 // Auth
 export interface SigninResponse {
-  api_key?: string;  // Deprecated: now returned via httpOnly cookie only
+  api_key?: string; // Deprecated: now returned via httpOnly cookie only
   user_id: string;
   stellar_address?: string | null;
   wallet_created?: boolean;
@@ -82,6 +82,7 @@ export interface TransferItem {
   local_amount?: string | null;
   recipient_address: string | null;
   blockchain_tx_hash?: string;
+  note?: string;
   created_at: string;
   completed_at?: string;
 }
@@ -111,6 +112,7 @@ export interface TransactionDetail {
   usdc_amount?: string | null;
   local_amount?: string | null;
   currency?: string;
+  note?: string;
   created_at: string;
   completed_at?: string;
   blockchain_tx_hash?: string;
@@ -143,7 +145,7 @@ export interface TransactionsListResponse {
 export interface MintFromUsdcBody {
   usdc_amount: string;
   wallet_address: string;
-  currency_preference?: 'auto';
+  currency_preference?: "auto";
 }
 
 export interface MintResponse {
@@ -168,7 +170,7 @@ export interface OnRampRegisterResponse {
 
 // Burn
 export interface BurnRecipientAccount {
-  type?: 'bank' | 'mobile_money';
+  type?: "bank" | "mobile_money";
   account_number: string;
   bank_code: string;
   account_name: string;


### PR DESCRIPTION
The `note` field entered during a transfer was captured in the send dialog and
forwarded to the API, but was never surfaced on the transfer or transaction
detail pages. This meant the compliance reference was silently dropped after
submission — users and auditors had no way to verify it from a receipt.

## Changes

| File                             | What changed                                                    |
| -------------------------------- | --------------------------------------------------------------- |
| `types/api.ts`                   | Added `note?: string` to `TransferItem` and `TransactionDetail` |
| `app/send/[id]/page.tsx`         | Extract and render `note` in the transfer detail card           |
| `app/transactions/[id]/page.tsx` | Extract and render `note` in the transaction detail card        |

## Acceptance check

1. Create a transfer with a note (e.g. "Invoice #42").
2. Open the transfer detail (`/send/<id>`) — note appears below the timestamps.
3. Open the same record via activity (`/transactions/<id>`) — note appears there too.
4. Transfers without a note show no note section (conditional render).

## Out of scope

PDF/email receipt generation is a backend concern and is not addressed here.
This PR ensures the frontend correctly receives and displays the note so that
any future receipt renderer has the data available.



closes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction and transfer detail pages now display notes when available, shown in a dedicated section above the transaction hash information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->