### PR TITLE
fix(reserves): add unit explanation tooltips — F-057 #228

### DIFF
--- a/app/reserves/page.tsx
+++ b/app/reserves/page.tsx
@@ -5,11 +5,30 @@ import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft } from 'lucide-react';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { ArrowLeft, Info } from 'lucide-react';
 import { useApiOpts } from '@/hooks/use-api';
 import * as reservesApi from '@/lib/api/reserves';
 import type { ReservesResponse } from '@/types/api';
 import { formatAmount } from '@/lib/utils';
+
+const DOCS_URL = '/docs/RESERVE_MANAGEMENT';
+
+function MetricLabel({ label, tip }: { label: string; tip: string }) {
+  return (
+    <span className="flex items-center gap-1 text-muted-foreground">
+      {label}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <a href={DOCS_URL} target="_blank" rel="noopener noreferrer" aria-label={`Learn more: ${label}`}>
+            <Info className="w-3.5 h-3.5 text-muted-foreground/60 hover:text-primary transition-colors" />
+          </a>
+        </TooltipTrigger>
+        <TooltipContent>{tip}</TooltipContent>
+      </Tooltip>
+    </span>
+  );
+}
 
 export default function ReservesPage() {
   const opts = useApiOpts();
@@ -64,7 +83,7 @@ export default function ReservesPage() {
             <Card className="border-border p-4 space-y-3">
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
-                  <span className="text-muted-foreground">Total reserves</span>
+                  <MetricLabel label="Total reserves" tip="On-chain USD value of all backing assets, stored as 7-decimal fixed-point integers." />
                   <span className="text-xs text-muted-foreground">On-chain USD value (7-dec fixed).</span>
                 </div>
                 <div className="flex flex-col items-end">
@@ -77,7 +96,7 @@ export default function ReservesPage() {
 
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
-                  <span className="text-muted-foreground">Total ACBU supply</span>
+                  <MetricLabel label="Total ACBU supply" tip="Total ACBU tokens in circulation, tracked by the minting contract." />
                   <span className="text-xs text-muted-foreground">Minting contract tracked supply.</span>
                 </div>
                 <div className="flex flex-col items-end">
@@ -89,7 +108,7 @@ export default function ReservesPage() {
 
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
-                  <span className="text-muted-foreground">Collateral ratio</span>
+                  <MetricLabel label="Collateral ratio" tip="Reserves ÷ ACBU supply in USD terms. Must stay above the minimum ratio to remain solvent." />
                   <span className="text-xs text-muted-foreground">Reserves ÷ supply (USD terms).</span>
                 </div>
                 <div className="flex flex-col items-end">
@@ -104,7 +123,7 @@ export default function ReservesPage() {
 
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
-                  <span className="text-muted-foreground">Health</span>
+                  <MetricLabel label="Health" tip="Issuer-reported reserve health status. Reflects whether collateral ratio and weight compliance are within acceptable bounds." />
                   <span className="text-xs text-muted-foreground">Issuer-reported status.</span>
                 </div>
                 <div className="flex flex-col items-end">
@@ -153,23 +172,23 @@ export default function ReservesPage() {
 
                     <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
                       <div className="flex flex-col">
-                        <span className="text-muted-foreground text-xs">Balance</span>
+                        <MetricLabel label="Balance" tip="Raw on-chain balance of this currency in the reserve pool." />
                         <span className="text-foreground">
                           {formatAmount(fixed7ToNumber(c.amount), 2)} {c.currency}
                         </span>
                       </div>
                       <div className="flex flex-col items-end">
-                        <span className="text-muted-foreground text-xs">USD value</span>
+                        <MetricLabel label="USD value" tip="Balance converted to USD at the current oracle rate." />
                         <span className="text-foreground">
                           USD {formatAmount(fixed7ToNumber(c.value_usd), 2)}
                         </span>
                       </div>
                       <div className="flex flex-col">
-                        <span className="text-muted-foreground text-xs">Target</span>
+                        <MetricLabel label="Target" tip="Desired portfolio weight for this currency (basis points ÷ 100 = %)." />
                         <span className="text-foreground">{formatPct(c.target_weight_bps)}</span>
                       </div>
                       <div className="flex flex-col items-end">
-                        <span className="text-muted-foreground text-xs">Actual</span>
+                        <MetricLabel label="Actual" tip="Current portfolio weight. Drift from target triggers a warning when outside the allowed threshold." />
                         <span className="text-foreground">{formatPct(c.actual_weight_bps)}</span>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary

Fixes #228 — Reserves page lacks unit explanations (F-057).

Users were misinterpreting health metrics on the reserves page due to missing context. This PR adds inline `Info` icon tooltips to every metric label, each linking to `/docs/RESERVE_MANAGEMENT` for deeper reading.

## Changes

- Added a minimal `MetricLabel` component with a Radix `Tooltip` and `Info` icon
- Tooltips cover all top-level metrics: **Total reserves**, **Total ACBU supply**, **Collateral ratio**, **Health**
- Per-currency composition metrics also covered: **Balance**, **USD value**, **Target weight**, **Actual weight**
- Icon links to `/docs/RESERVE_MANAGEMENT` (opens in new tab)
- No new dependencies — uses existing `@/components/ui/tooltip` and `lucide-react`

## Acceptance

- [x] Every health metric has a tooltip explaining its unit/meaning
- [x] Tooltip links to RESERVE_MANAGEMENT docs
- [x] No TypeScript errors introduced
- [x] Severity: Low — UI-only change, no logic touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive info icons to reserve metrics for enhanced clarity
  * Hovering over icons displays metric-specific explanations via tooltips
  * Clicking icons opens reserve management documentation in a new tab

<!-- end of auto-generated comment: release notes by coderabbit.ai -->