### PR TITLE
feat: add savings dashboard with deposit and withdrawal pages

### DIFF
--- a/app/savings/deposit/page.tsx
+++ b/app/savings/deposit/page.tsx
@@ -6,10 +6,31 @@ import { PageContainer } from "@/components/layout/page-container";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, AlertCircle } from "lucide-react";
 import { useApiOpts } from "@/hooks/use-api";
 import * as userApi from "@/lib/api/user";
 import * as savingsApi from "@/lib/api/savings";
+import { resolveRecipient } from "@/lib/api/recipient";
+
+/**
+ * Resolve any user identifier (Stellar address, phone, alias, pay URI)
+ * through the backend recipient resolver to obtain the canonical pay_uri.
+ * Falls back to the raw value when the resolver is unavailable so that
+ * Stellar-format addresses still work offline.
+ */
+async function resolveUserUri(
+    raw: string,
+    opts: Parameters<typeof resolveRecipient>[1],
+): Promise<string> {
+    try {
+        const resolved = await resolveRecipient(raw, opts);
+        if (resolved.pay_uri) return resolved.pay_uri;
+        if (resolved.alias) return resolved.alias;
+    } catch {
+        // Resolver unavailable — fall through to raw value.
+    }
+    return raw;
+}
 
 export default function SavingsDepositPage() {
     const opts = useApiOpts();
@@ -17,22 +38,42 @@ export default function SavingsDepositPage() {
     const [amount, setAmount] = useState("");
     const [termSeconds, setTermSeconds] = useState("0");
     const [loading, setLoading] = useState(false);
+    const [resolving, setResolving] = useState(false);
     const [error, setError] = useState("");
     const [success, setSuccess] = useState("");
 
   useEffect(() => {
-    userApi.getReceive(opts).then((data) => {
+    let cancelled = false;
+    setResolving(true);
+    setError("");
+
+    userApi.getReceive(opts).then(async (data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
-      if (uri && typeof uri === 'string') setUser(uri);
+      if (!uri || typeof uri !== 'string') {
+        if (!cancelled) setResolving(false);
+        return;
+      }
+
+      // Resolve through backend recipient resolver so phone-based IDs,
+      // aliases, and other non-Stellar identifiers are accepted.
+      const resolved = await resolveUserUri(uri, opts);
+      if (!cancelled) setUser(resolved);
     }).catch((e) => {
-      console.error(e instanceof Error ? e.message : 'Failed to load receive address');
+      if (!cancelled) {
+        setError(e instanceof Error ? e.message : 'Failed to load receive address');
+      }
+    }).finally(() => {
+      if (!cancelled) setResolving(false);
     });
+
+    return () => { cancelled = true; };
   }, [opts.token]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         if (!user.trim() || !amount || parseFloat(amount) <= 0) return;
         setError("");
+        setSuccess("");
         setLoading(true);
         try {
             await savingsApi.savingsDeposit(
@@ -66,7 +107,10 @@ export default function SavingsDepositPage() {
             <PageContainer>
                 <Card className="border-border p-4 space-y-4">
                     {error && (
-                        <p className="text-destructive text-sm">{error}</p>
+                        <div className="flex items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
+                            <AlertCircle className="h-4 w-4 shrink-0" />
+                            <p>{error}</p>
+                        </div>
                     )}
                     {success && (
                         <p className="text-green-600 text-sm">{success}</p>
@@ -81,10 +125,15 @@ export default function SavingsDepositPage() {
                             </label>
                             <Input
                                 id="deposit-account"
-                                value={user}
+                                value={resolving ? "Resolving…" : user}
                                 readOnly
                                 className="border-border font-mono text-sm bg-muted"
                             />
+                            {resolving && (
+                                <p className="text-xs text-muted-foreground mt-1">
+                                    Verifying account identifier…
+                                </p>
+                            )}
                         </div>
                         <div>
                             <label
@@ -121,9 +170,9 @@ export default function SavingsDepositPage() {
                         </div>
                         <Button
                             type="submit"
-                            disabled={loading || !user.trim() || !amount}
+                            disabled={loading || resolving || !user.trim() || !amount}
                         >
-                            Deposit
+                            {loading ? "Depositing…" : "Deposit"}
                         </Button>
                     </form>
                 </Card>

--- a/app/savings/page.tsx
+++ b/app/savings/page.tsx
@@ -28,7 +28,28 @@ import { PageContainer } from "@/components/layout/page-container";
 import { useApiOpts } from "@/hooks/use-api";
 import * as userApi from "@/lib/api/user";
 import * as savingsApi from "@/lib/api/savings";
+import { resolveRecipient } from "@/lib/api/recipient";
 import { formatAmount } from "@/lib/utils";
+
+/**
+ * Resolve any user identifier (Stellar address, phone, alias, pay URI)
+ * through the backend recipient resolver to obtain the canonical pay_uri.
+ * Falls back to the raw value when the resolver is unavailable so that
+ * Stellar-format addresses still work offline.
+ */
+async function resolveUserUri(
+  raw: string,
+  opts: Parameters<typeof resolveRecipient>[1],
+): Promise<string> {
+  try {
+    const resolved = await resolveRecipient(raw, opts);
+    if (resolved.pay_uri) return resolved.pay_uri;
+    if (resolved.alias) return resolved.alias;
+  } catch {
+    // Resolver unavailable — fall through to raw value.
+  }
+  return raw;
+}
 
 interface SavingsAccount {
     id: string;
@@ -118,12 +139,21 @@ export default function SavingsPage() {
   const [newGoalDeadline, setNewGoalDeadline] = useState("");
 
   useEffect(() => {
+    let cancelled = false;
     setReceiveError("");
-    userApi.getReceive(opts).then((data) => {
+    userApi.getReceive(opts).then(async (data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
-      if (uri && typeof uri === "string") setApiUser(uri);
-      setReceiveError("");
-    }).catch((e) => setReceiveError(e instanceof Error ? e.message : "Failed to load user info"));
+      if (uri && typeof uri === "string") {
+        // Resolve through backend recipient resolver so phone-based IDs,
+        // aliases, and other non-Stellar identifiers are accepted.
+        const resolved = await resolveUserUri(uri, opts);
+        if (!cancelled) setApiUser(resolved);
+      }
+      if (!cancelled) setReceiveError("");
+    }).catch((e) => {
+      if (!cancelled) setReceiveError(e instanceof Error ? e.message : "Failed to load user info");
+    });
+    return () => { cancelled = true; };
   }, [opts.token]);
 
   useEffect(() => {

--- a/app/savings/withdraw/page.tsx
+++ b/app/savings/withdraw/page.tsx
@@ -6,10 +6,31 @@ import { PageContainer } from "@/components/layout/page-container";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, AlertCircle } from "lucide-react";
 import { useApiOpts } from "@/hooks/use-api";
 import * as userApi from "@/lib/api/user";
 import * as savingsApi from "@/lib/api/savings";
+import { resolveRecipient } from "@/lib/api/recipient";
+
+/**
+ * Resolve any user identifier (Stellar address, phone, alias, pay URI)
+ * through the backend recipient resolver to obtain the canonical pay_uri.
+ * Falls back to the raw value when the resolver is unavailable so that
+ * Stellar-format addresses still work offline.
+ */
+async function resolveUserUri(
+    raw: string,
+    opts: Parameters<typeof resolveRecipient>[1],
+): Promise<string> {
+    try {
+        const resolved = await resolveRecipient(raw, opts);
+        if (resolved.pay_uri) return resolved.pay_uri;
+        if (resolved.alias) return resolved.alias;
+    } catch {
+        // Resolver unavailable — fall through to raw value.
+    }
+    return raw;
+}
 
 export default function SavingsWithdrawPage() {
     const opts = useApiOpts();
@@ -17,30 +38,50 @@ export default function SavingsWithdrawPage() {
     const [termSeconds, setTermSeconds] = useState("0");
     const [amount, setAmount] = useState("");
     const [loading, setLoading] = useState(false);
+    const [resolving, setResolving] = useState(false);
     const [error, setError] = useState("");
     const [success, setSuccess] = useState("");
 
     useEffect(() => {
+        let cancelled = false;
+        setResolving(true);
+        setError("");
+
         userApi
             .getReceive(opts)
-            .then((data) => {
+            .then(async (data) => {
                 const uri = (data.pay_uri ?? data.alias) as string | undefined;
-                if (uri && typeof uri === "string")
-                    setUser(uri);
+                if (!uri || typeof uri !== "string") {
+                    if (!cancelled) setResolving(false);
+                    return;
+                }
+
+                // Resolve through backend recipient resolver so phone-based IDs,
+                // aliases, and other non-Stellar identifiers are accepted.
+                const resolved = await resolveUserUri(uri, opts);
+                if (!cancelled) setUser(resolved);
             })
             .catch((e) => {
-                console.error(
-                    e instanceof Error
-                        ? e.message
-                        : "Failed to load receive address",
-                );
+                if (!cancelled) {
+                    setError(
+                        e instanceof Error
+                            ? e.message
+                            : "Failed to load receive address",
+                    );
+                }
+            })
+            .finally(() => {
+                if (!cancelled) setResolving(false);
             });
+
+        return () => { cancelled = true; };
     }, [opts.token]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         if (!user.trim() || !amount || parseFloat(amount) <= 0) return;
         setError("");
+        setSuccess("");
         setLoading(true);
         try {
             await savingsApi.savingsWithdraw(
@@ -74,7 +115,10 @@ export default function SavingsWithdrawPage() {
             <PageContainer>
                 <Card className="border-border p-4 space-y-4">
                     {error && (
-                        <p className="text-destructive text-sm">{error}</p>
+                        <div className="flex items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-destructive">
+                            <AlertCircle className="h-4 w-4 shrink-0" />
+                            <p>{error}</p>
+                        </div>
                     )}
                     {success && (
                         <p className="text-green-600 text-sm">{success}</p>
@@ -89,10 +133,15 @@ export default function SavingsWithdrawPage() {
                             </label>
                             <Input
                                 id="withdraw-account"
-                                value={user}
+                                value={resolving ? "Resolving…" : user}
                                 readOnly
                                 className="border-border font-mono text-sm bg-muted"
                             />
+                            {resolving && (
+                                <p className="text-xs text-muted-foreground mt-1">
+                                    Verifying account identifier…
+                                </p>
+                            )}
                         </div>
                         <div>
                             <label
@@ -129,9 +178,9 @@ export default function SavingsWithdrawPage() {
                         </div>
                         <Button
                             type="submit"
-                            disabled={loading || !user.trim() || !amount}
+                            disabled={loading || resolving || !user.trim() || !amount}
                         >
-                            Withdraw
+                            {loading ? "Withdrawing…" : "Withdraw"}
                         </Button>
                     </form>
                 </Card>


### PR DESCRIPTION
Closes #212 

Summary

Root Cause
The deposit, withdraw, and savings overview pages passed the raw user identifier (from GET /users/me/receive) directly to savings API endpoints. Phone-based IDs and short aliases were rejected because the savings backend expected a canonical pay_uri format.

Fix
Added a resolveUserUri() helper that calls GET /recipient?q=<identifier> to canonicalise any identifier (phone, alias, Stellar address) into the format the savings backend accepts. Applied to:

savings/deposit/page.tsx — resolves before deposit submission
savings/withdraw/page.tsx — resolves before withdrawal submission
savings/page.tsx — resolves before fetching savings positions
Safety
Graceful fallback: If the resolver is down, the raw URI passes through (Stellar addresses still work)
Race condition handling: Cleanup flags prevent stale state after unmount
UX: Shows "Resolving…" indicator while canonicalising
TypeScript compiles cleanly (only pre-existing lucide-react type errors unrelated to this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time feedback when resolving account recipients, displaying status messages to users during the resolution process
  * Enhanced error messages with improved visual presentation using alert-style notifications with icons
  * Updated deposit and withdrawal action buttons to display processing states ("Depositing…", "Withdrawing…") while requests are in flight
  * Improved form validation to prevent submission while recipient resolution is in progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->