### PR TITLE
fix: add aria-label to mobile nav icon links

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -41,7 +41,7 @@ export function MobileNav() {
             <Link
               key={item.href}
               href={item.href}
-              aria-label={showLabels ? undefined : item.name}
+              aria-label={item.name}
               className={`flex flex-col items-center justify-center flex-1 h-20 gap-1 transition-colors ${
                 isActive
                   ? "text-primary"


### PR DESCRIPTION
Fixes #218 

## What this PR does
- Fixed `aria-label` on mobile nav links which was set to `undefined` when labels were visible
- Changed `aria-label={showLabels ? undefined : item.name}` to `aria-label={item.name}`
- VoiceOver will now correctly read "Home", "Send", "Mint", "Business", "Wallet", "Me" for each nav link

## How to verify
- Enable VoiceOver on iOS and navigate to the mobile nav
- Each icon link should be announced by its destination name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of the mobile navigation by consistently providing screen reader labels for all navigation links, enhancing support for assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->