### PR TITLE
Signup passcode minimum too weak

### DIFF
--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -9,6 +9,59 @@ import { Card } from "@/components/ui/card";
 import { AlertCircle, Eye, EyeOff } from "lucide-react";
 import * as authApi from "@/lib/api/auth";
 
+const MIN_PASSCODE_LENGTH = 12;
+const PASSCODE_POLICY_MESSAGE =
+    "Passcode must be at least 12 characters and include uppercase, lowercase, number, and special character.";
+const STRONG_PASSCODE_MIN_SCORE = 4;
+const PASSCODE_REGEX =
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).{12,}$/;
+
+const PASSCODE_WEAK_PATTERNS = [
+    "password",
+    "passcode",
+    "qwerty",
+    "letmein",
+    "123456",
+    "abcdef",
+];
+
+const getPasscodeStrength = (value: string) => {
+    let score = 0;
+
+    if (value.length >= MIN_PASSCODE_LENGTH) score += 1;
+    if (value.length >= 16) score += 1;
+    if (/[a-z]/.test(value)) score += 1;
+    if (/[A-Z]/.test(value)) score += 1;
+    if (/\d/.test(value)) score += 1;
+    if (/[^A-Za-z\d]/.test(value)) score += 1;
+
+    if (/(.)\1{2,}/.test(value)) score -= 1;
+    if (/(0123|1234|2345|3456|4567|5678|6789)/.test(value)) score -= 1;
+    if (/(abcd|bcde|cdef|defg|efgh|fghi|ghij)/i.test(value)) score -= 1;
+
+    const lowered = value.toLowerCase();
+    if (PASSCODE_WEAK_PATTERNS.some((pattern) => lowered.includes(pattern))) {
+        score -= 2;
+    }
+
+    const normalizedScore = Math.max(0, Math.min(5, score));
+    const labels = ["Very weak", "Weak", "Fair", "Good", "Strong", "Very strong"];
+    const barColors = [
+        "bg-destructive/80",
+        "bg-orange-500/80",
+        "bg-amber-500/80",
+        "bg-lime-500/80",
+        "bg-emerald-500/80",
+        "bg-emerald-500",
+    ];
+
+    return {
+        score: normalizedScore,
+        label: labels[normalizedScore],
+        barColor: barColors[normalizedScore],
+    };
+};
+
 export default function SignUpPage() {
     const router = useRouter();
     const [username, setUsername] = useState("");
@@ -24,24 +77,25 @@ export default function SignUpPage() {
     }
 
     const handleSignUp = async (e: React.FormEvent) => {
-        const passwordRegex =
-            /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
-
         e.preventDefault();
         setError("");
         if (passcode !== confirmPasscode) {
             setError("Passcodes do not match");
             return;
         }
-        if (passcode.length < 8) {
-            setError("Passcode must be at least 8 characters");
+        if (passcode.length < MIN_PASSCODE_LENGTH) {
+            setError(`Passcode must be at least ${MIN_PASSCODE_LENGTH} characters`);
             return;
         }
 
-        if (!passwordRegex.test(passcode)) {
-            setError(
-                "Passcode must be at least 8 characters and include uppercase, lowercase, number, and special character",
-            );
+        if (!PASSCODE_REGEX.test(passcode)) {
+            setError(PASSCODE_POLICY_MESSAGE);
+            return;
+        }
+
+        const { score } = getPasscodeStrength(passcode);
+        if (score < STRONG_PASSCODE_MIN_SCORE) {
+            setError("Passcode is too weak. Please choose a stronger passcode.");
             return;
         }
         if (!username) {
@@ -60,6 +114,8 @@ export default function SignUpPage() {
             setLoading(false);
         }
     };
+
+    const passcodeStrength = getPasscodeStrength(passcode);
 
     return (
         <div className="min-h-screen bg-background flex items-center justify-center p-4">
@@ -114,7 +170,7 @@ export default function SignUpPage() {
                                 htmlFor="signup-passcode"
                                 className="text-sm font-medium text-foreground mb-2 block"
                             >
-                                Passcode (min 8 characters)
+                                Passcode (min 12 characters)
                             </label>
                             <div className="relative">
                                 <Input
@@ -143,6 +199,31 @@ export default function SignUpPage() {
                                     )}
                                 </button>
                             </div>
+                            {passcode.length > 0 && (
+                                <div className="mt-3 space-y-2">
+                                    <div className="grid grid-cols-5 gap-1">
+                                        {Array.from({ length: 5 }).map((_, idx) => (
+                                            <div
+                                                key={idx}
+                                                className={`h-1.5 rounded-full ${
+                                                    idx < passcodeStrength.score
+                                                        ? passcodeStrength.barColor
+                                                        : "bg-muted"
+                                                }`}
+                                            />
+                                        ))}
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        Strength:{" "}
+                                        <span className="font-medium text-foreground">
+                                            {passcodeStrength.label}
+                                        </span>
+                                    </p>
+                                </div>
+                            )}
+                            <p className="mt-2 text-xs text-muted-foreground">
+                                {PASSCODE_POLICY_MESSAGE}
+                            </p>
                         </div>
 
                         <div>


### PR DESCRIPTION
close #222 


Description
Raise minimum passcode length to 12 and centralize policy constants and message with a stricter regex requiring uppercase, lowercase, number, and special character (PASSCODE_REGEX, MIN_PASSCODE_LENGTH).
Add a client-side passcode strength scorer with penalties for repeated, sequential, and common weak patterns and expose a score/label/color set via getPasscodeStrength.
Enforce a minimum strength threshold during signup submission so weak passcodes are rejected client-side before calling the signup API.
Add a visual strength meter and live strength label and show the updated policy guidance text on the signup form.



Testing
Ran npx eslint app/auth/signup/page.tsx which passed for the modified file.
Ran npm run lint which failed due to pre-existing unrelated lint errors in other files and not due to the changes in app/auth/signup/page.tsx.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time passcode strength meter with visual feedback during signup.
  * Passcode policy requirements now display dynamically as users type.

* **Bug Fixes**
  * Updated passcode validation with increased minimum length to 12 characters and enhanced complexity requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->