### PR TITLE
feat(lending): add loan application intake + backoffice stub (#189)

### DIFF
--- a/app/lending/admin/page.tsx
+++ b/app/lending/admin/page.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Inbox, RefreshCw, CheckCircle2, XCircle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { PageContainer } from '@/components/layout/page-container';
+import { formatAmount } from '@/lib/utils';
+import {
+  listApplications,
+  updateApplicationStatus,
+  type StoredLoanApplication,
+} from '@/lib/lending-store';
+
+/**
+ * Backoffice stub — reads submissions from the local persistence layer
+ * so reviewers can see that the intake flow is wired end-to-end. When the
+ * real backend is online, this same page can be repointed at the server.
+ */
+export default function LendingAdminPage() {
+  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+
+  const refresh = () => setApplications(listApplications());
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const totalApproved = applications
+    .filter((a) => a.status === 'approved')
+    .reduce((sum, a) => sum + a.amount, 0);
+  const totalPending = applications.filter((a) =>
+    a.status === 'pending' || a.status === 'submitted'
+  ).length;
+
+  const handleDecision = (id: string, status: 'approved' | 'rejected') => {
+    const next = updateApplicationStatus(id, status);
+    setApplications(next);
+  };
+
+  return (
+    <>
+      <header className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
+        <div className="mx-auto max-w-md px-4 py-4 flex items-center gap-3">
+          <Link href="/lending" className="p-2 hover:bg-muted rounded transition-colors" aria-label="Back to lending">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <div className="flex-1">
+            <h1 className="text-lg font-bold text-foreground">Lending · Backoffice</h1>
+            <p className="text-xs text-muted-foreground">Review loan applications</p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={refresh}
+            className="border-border bg-transparent"
+          >
+            <RefreshCw className="w-3.5 h-3.5 mr-1" /> Refresh
+          </Button>
+        </div>
+      </header>
+
+      <PageContainer>
+        <div className="space-y-5">
+          <div className="grid grid-cols-2 gap-3">
+            <Card className="border-border p-4">
+              <p className="text-xs text-muted-foreground mb-1">Pending review</p>
+              <p className="text-2xl font-bold text-foreground">{totalPending}</p>
+            </Card>
+            <Card className="border-border p-4">
+              <p className="text-xs text-muted-foreground mb-1">Approved (ACBU)</p>
+              <p className="text-2xl font-bold text-foreground">
+                {formatAmount(totalApproved)}
+              </p>
+            </Card>
+          </div>
+
+          <div className="space-y-3">
+            <h2 className="text-sm font-semibold text-foreground">
+              All applications ({applications.length})
+            </h2>
+
+            {applications.length === 0 ? (
+              <Card className="border-border p-6 flex flex-col items-center text-center gap-3">
+                <Inbox className="w-10 h-10 text-muted-foreground" />
+                <p className="text-sm font-medium text-foreground">No applications yet</p>
+                <p className="text-xs text-muted-foreground">
+                  Submitted applications from{' '}
+                  <Link href="/lending" className="text-primary underline-offset-2 hover:underline">
+                    the lending form
+                  </Link>{' '}
+                  will appear here.
+                </p>
+              </Card>
+            ) : (
+              <div className="space-y-3">
+                {applications.map((app) => (
+                  <Card key={app.id} className="border-border p-4 space-y-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-semibold text-foreground">{app.productName}</p>
+                        <p className="text-xs text-muted-foreground">
+                          ACBU {formatAmount(app.amount)} · {app.term} months
+                        </p>
+                      </div>
+                      <div className="flex flex-col items-end gap-1">
+                        <Badge
+                          variant={
+                            app.status === 'approved'
+                              ? 'default'
+                              : app.status === 'rejected'
+                                ? 'destructive'
+                                : 'secondary'
+                          }
+                          className="text-[10px] capitalize"
+                        >
+                          {app.status}
+                        </Badge>
+                        <Badge
+                          variant="outline"
+                          className="text-[9px] uppercase tracking-wide"
+                        >
+                          {app.syncedWithBackend ? 'synced' : 'local'}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                      <dt className="text-muted-foreground">Applicant</dt>
+                      <dd className="text-foreground truncate">
+                        {app.applicantUser ?? '—'}
+                      </dd>
+                      <dt className="text-muted-foreground">Submitted</dt>
+                      <dd className="text-foreground">
+                        {new Date(app.submittedAt).toLocaleString()}
+                      </dd>
+                      <dt className="text-muted-foreground">Reference</dt>
+                      <dd className="text-foreground font-mono truncate">{app.id}</dd>
+                      {app.purpose && (
+                        <>
+                          <dt className="text-muted-foreground">Purpose</dt>
+                          <dd className="text-foreground whitespace-pre-wrap">
+                            {app.purpose}
+                          </dd>
+                        </>
+                      )}
+                      {app.errorMessage && (
+                        <>
+                          <dt className="text-muted-foreground">Sync note</dt>
+                          <dd className="text-amber-700 dark:text-amber-400">
+                            {app.errorMessage}
+                          </dd>
+                        </>
+                      )}
+                    </dl>
+
+                    {(app.status === 'pending' || app.status === 'submitted') && (
+                      <div className="flex gap-2 pt-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="flex-1 border-green-500/40 text-green-700 hover:bg-green-500/10 bg-transparent dark:text-green-400"
+                          onClick={() => handleDecision(app.id, 'approved')}
+                        >
+                          <CheckCircle2 className="w-3.5 h-3.5 mr-1" /> Approve
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="flex-1 border-destructive/40 text-destructive hover:bg-destructive/10 bg-transparent"
+                          onClick={() => handleDecision(app.id, 'rejected')}
+                        >
+                          <XCircle className="w-3.5 h-3.5 mr-1" /> Reject
+                        </Button>
+                      </div>
+                    )}
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </PageContainer>
+    </>
+  );
+}

--- a/app/lending/page.tsx
+++ b/app/lending/page.tsx
@@ -1,0 +1,441 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Briefcase, HandCoins, ShieldAlert, CheckCircle2, AlertCircle, Clock, Wallet } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { PageContainer } from '@/components/layout/page-container';
+import { useApiOpts } from '@/hooks/use-api';
+import * as lendingApi from '@/lib/api/lending';
+import * as userApi from '@/lib/api/user';
+import { formatAmount } from '@/lib/utils';
+import {
+  listApplications,
+  saveApplication,
+  type StoredLoanApplication,
+} from '@/lib/lending-store';
+
+interface LoanProduct {
+  id: string;
+  name: string;
+  description: string;
+  minAmount: number;
+  maxAmount: number;
+  minTerm: number;
+  maxTerm: number;
+  ratePct: number;
+  icon: LucideIcon;
+}
+
+const LOAN_PRODUCTS: LoanProduct[] = [
+  {
+    id: 'personal',
+    name: 'Personal loan',
+    description: 'Unsecured credit for general use',
+    minAmount: 50,
+    maxAmount: 5000,
+    minTerm: 3,
+    maxTerm: 24,
+    ratePct: 12,
+    icon: HandCoins,
+  },
+  {
+    id: 'business',
+    name: 'Business loan',
+    description: 'Working capital for SMEs',
+    minAmount: 500,
+    maxAmount: 25000,
+    minTerm: 6,
+    maxTerm: 36,
+    ratePct: 9,
+    icon: Briefcase,
+  },
+  {
+    id: 'emergency',
+    name: 'Emergency loan',
+    description: 'Fast short-term liquidity',
+    minAmount: 25,
+    maxAmount: 1000,
+    minTerm: 1,
+    maxTerm: 6,
+    ratePct: 15,
+    icon: ShieldAlert,
+  },
+];
+
+function generateLocalId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `local-${crypto.randomUUID()}`;
+  }
+  return `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export default function LendingPage() {
+  const opts = useApiOpts();
+
+  const [apiUser, setApiUser] = useState('');
+  const [balance, setBalance] = useState<string | number | null>(null);
+  const [balanceLoading, setBalanceLoading] = useState(false);
+
+  const [productId, setProductId] = useState<string>(LOAN_PRODUCTS[0].id);
+  const [amount, setAmount] = useState('');
+  const [term, setTerm] = useState('');
+  const [purpose, setPurpose] = useState('');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [warningMessage, setWarningMessage] = useState('');
+
+  const [applications, setApplications] = useState<StoredLoanApplication[]>([]);
+
+  useEffect(() => {
+    setApplications(listApplications());
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    userApi
+      .getReceive(opts)
+      .then((data) => {
+        const uri = (data.pay_uri ?? data.alias) as string | undefined;
+        if (!cancelled && uri) setApiUser(uri);
+      })
+      .catch(() => {
+        /* ignore — lender identity falls back to empty */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [opts.token]);
+
+  useEffect(() => {
+    if (!apiUser) return;
+    let cancelled = false;
+    setBalanceLoading(true);
+    lendingApi
+      .getLendingBalance(apiUser, opts)
+      .then((res) => {
+        if (!cancelled) setBalance(res.balance);
+      })
+      .catch(() => {
+        if (!cancelled) setBalance(null);
+      })
+      .finally(() => {
+        if (!cancelled) setBalanceLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUser, opts.token]);
+
+  const selectedProduct = useMemo(
+    () => LOAN_PRODUCTS.find((p) => p.id === productId) ?? LOAN_PRODUCTS[0],
+    [productId]
+  );
+
+  const parsedAmount = parseFloat(amount);
+  const parsedTerm = parseInt(term, 10);
+  const amountValid =
+    Number.isFinite(parsedAmount) &&
+    parsedAmount >= selectedProduct.minAmount &&
+    parsedAmount <= selectedProduct.maxAmount;
+  const termValid =
+    Number.isFinite(parsedTerm) &&
+    parsedTerm >= selectedProduct.minTerm &&
+    parsedTerm <= selectedProduct.maxTerm;
+  const canSubmit = amountValid && termValid && !submitting;
+
+  const resetForm = () => {
+    setAmount('');
+    setTerm('');
+    setPurpose('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError('');
+    setSuccessMessage('');
+    setWarningMessage('');
+
+    if (!amountValid) {
+      setFormError(
+        `Amount must be between ACBU ${selectedProduct.minAmount} and ACBU ${selectedProduct.maxAmount}.`
+      );
+      return;
+    }
+    if (!termValid) {
+      setFormError(
+        `Term must be between ${selectedProduct.minTerm} and ${selectedProduct.maxTerm} months.`
+      );
+      return;
+    }
+
+    setSubmitting(true);
+
+    let loanId = generateLocalId();
+    let synced = false;
+    let errorMessage: string | undefined;
+
+    try {
+      const res = await lendingApi.applyForLoan(
+        {
+          productId: selectedProduct.id,
+          amount: parsedAmount,
+          term: parsedTerm,
+        },
+        opts
+      );
+      if (res.loanId) loanId = res.loanId;
+      synced = Boolean(res.success);
+    } catch (err) {
+      errorMessage = err instanceof Error ? err.message : 'Backend sync failed';
+    }
+
+    const record: StoredLoanApplication = {
+      id: loanId,
+      productId: selectedProduct.id,
+      productName: selectedProduct.name,
+      amount: parsedAmount,
+      term: parsedTerm,
+      purpose: purpose.trim() || undefined,
+      applicantUser: apiUser || undefined,
+      status: synced ? 'submitted' : 'pending',
+      syncedWithBackend: synced,
+      submittedAt: new Date().toISOString(),
+      errorMessage,
+    };
+
+    const next = saveApplication(record);
+    setApplications(next);
+    resetForm();
+    setSubmitting(false);
+
+    if (synced) {
+      setSuccessMessage(`Application submitted. Reference: ${loanId}`);
+    } else {
+      setSuccessMessage(`Application saved (ref ${loanId}).`);
+      setWarningMessage(
+        errorMessage
+          ? `Pending backend sync — backoffice stub captured the submission. (${errorMessage})`
+          : 'Pending backend sync — backoffice stub captured the submission.'
+      );
+    }
+  };
+
+  return (
+    <>
+      <header className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
+        <div className="mx-auto max-w-md px-4 py-4 flex items-center gap-3">
+          <Link href="/" className="p-2 hover:bg-muted rounded transition-colors" aria-label="Go back">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <div className="flex-1">
+            <h1 className="text-lg font-bold text-foreground">Lending</h1>
+            <p className="text-xs text-muted-foreground">Apply for a loan</p>
+          </div>
+          <Link
+            href="/lending/admin"
+            className="text-xs font-medium text-primary hover:underline"
+          >
+            Backoffice
+          </Link>
+        </div>
+      </header>
+
+      <PageContainer>
+        <div className="space-y-6">
+          <Card className="border-border bg-gradient-to-br from-amber-500/10 to-amber-600/10 p-5">
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-sm font-semibold text-foreground">Lending position</h2>
+              <Wallet className="w-5 h-5 text-amber-600" />
+            </div>
+            <p className="text-2xl font-bold text-foreground">
+              {balanceLoading
+                ? '—'
+                : apiUser
+                  ? `ACBU ${formatAmount(balance ?? 0)}`
+                  : 'Sign in to view'}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {apiUser ? `Lender: ${apiUser}` : 'Lender identity unavailable'}
+            </p>
+          </Card>
+
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold text-foreground">Choose a product</h3>
+            <div className="grid grid-cols-1 gap-3">
+              {LOAN_PRODUCTS.map((product) => {
+                const Icon = product.icon;
+                const active = product.id === productId;
+                return (
+                  <button
+                    key={product.id}
+                    type="button"
+                    onClick={() => setProductId(product.id)}
+                    className={`w-full text-left rounded-xl border transition-all p-4 ${
+                      active
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border bg-card hover:border-primary/50'
+                    }`}
+                    aria-pressed={active}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 rounded-lg bg-muted">
+                        <Icon className="w-5 h-5" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="font-semibold text-foreground">{product.name}</p>
+                          <Badge variant="secondary" className="text-[10px]">
+                            {product.ratePct}% APR
+                          </Badge>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {product.description}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground mt-1">
+                          ACBU {product.minAmount}–{product.maxAmount} ·{' '}
+                          {product.minTerm}–{product.maxTerm} months
+                        </p>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <Card className="border-border p-4">
+            <h3 className="text-sm font-semibold text-foreground mb-4">
+              Application details
+            </h3>
+            <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+              <div className="space-y-2">
+                <Label htmlFor="loan-amount" className="text-foreground">
+                  Amount (ACBU)
+                </Label>
+                <Input
+                  id="loan-amount"
+                  type="number"
+                  inputMode="decimal"
+                  min={selectedProduct.minAmount}
+                  max={selectedProduct.maxAmount}
+                  step="any"
+                  placeholder={`${selectedProduct.minAmount} – ${selectedProduct.maxAmount}`}
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  className="border-border"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="loan-term" className="text-foreground">
+                  Term (months)
+                </Label>
+                <Input
+                  id="loan-term"
+                  type="number"
+                  inputMode="numeric"
+                  min={selectedProduct.minTerm}
+                  max={selectedProduct.maxTerm}
+                  step="1"
+                  placeholder={`${selectedProduct.minTerm} – ${selectedProduct.maxTerm}`}
+                  value={term}
+                  onChange={(e) => setTerm(e.target.value)}
+                  className="border-border"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="loan-purpose" className="text-foreground">
+                  Purpose (optional)
+                </Label>
+                <Textarea
+                  id="loan-purpose"
+                  placeholder="How will you use the funds?"
+                  value={purpose}
+                  onChange={(e) => setPurpose(e.target.value)}
+                  rows={3}
+                  maxLength={500}
+                  className="border-border"
+                />
+              </div>
+
+              {formError && (
+                <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+                  <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                  <p>{formError}</p>
+                </div>
+              )}
+              {successMessage && (
+                <div className="flex items-start gap-2 rounded-lg border border-green-500/30 bg-green-500/5 p-3 text-xs text-green-700 dark:text-green-400">
+                  <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5" />
+                  <p>{successMessage}</p>
+                </div>
+              )}
+              {warningMessage && (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-amber-700 dark:text-amber-400">
+                  <Clock className="h-4 w-4 shrink-0 mt-0.5" />
+                  <p>{warningMessage}</p>
+                </div>
+              )}
+
+              <Button type="submit" disabled={!canSubmit} className="w-full">
+                {submitting ? 'Submitting…' : 'Submit application'}
+              </Button>
+            </form>
+          </Card>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-foreground">Your applications</h3>
+              <Link href="/lending/admin" className="text-xs text-primary font-medium">
+                View all
+              </Link>
+            </div>
+            {applications.length === 0 ? (
+              <Card className="border-border p-4">
+                <p className="text-sm text-muted-foreground">
+                  No applications yet. Submit one above to see it here.
+                </p>
+              </Card>
+            ) : (
+              <div className="space-y-2">
+                {applications.slice(0, 5).map((app) => (
+                  <Card key={app.id} className="border-border p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-semibold text-foreground text-sm">
+                          {app.productName}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          ACBU {formatAmount(app.amount)} · {app.term} months
+                        </p>
+                        <p className="text-[10px] text-muted-foreground mt-1 truncate">
+                          Ref: {app.id}
+                        </p>
+                      </div>
+                      <Badge
+                        variant={app.syncedWithBackend ? 'default' : 'secondary'}
+                        className="text-[10px] capitalize"
+                      >
+                        {app.status}
+                      </Badge>
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </PageContainer>
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import {
   Clock,
   Building2,
   ArrowUpRight,
+  HandCoins,
 } from 'lucide-react';
 import { PageContainer } from '@/components/layout/page-container';
 import { SkeletonList } from '@/components/ui/skeleton-list';
@@ -90,6 +91,7 @@ const features = [
   { title: 'Mint', description: 'Create ACBU', icon: Coins, href: '/mint', color: 'bg-purple-100 dark:bg-purple-900/30', iconColor: 'text-purple-600 dark:text-purple-400' },
   { title: 'Simulated Bank', description: 'Demo Fiat', icon: Building2, href: '/fiat', color: 'bg-green-100 dark:bg-green-900/30', iconColor: 'text-green-600 dark:text-green-400' },
   { title: 'Rates', description: 'Market rates', icon: TrendingUp, href: '/rates', color: 'bg-amber-100 dark:bg-amber-900/30', iconColor: 'text-amber-600 dark:text-amber-400' },
+  { title: 'Lending', description: 'Apply for a loan', icon: HandCoins, href: '/lending', color: 'bg-orange-100 dark:bg-orange-900/30', iconColor: 'text-orange-600 dark:text-orange-400' },
 ];
 
 function formatDate(iso: string) {

--- a/lib/lending-store.ts
+++ b/lib/lending-store.ts
@@ -1,0 +1,67 @@
+/**
+ * Local persistence for submitted loan applications.
+ *
+ * Why: the `/lending/apply` backend endpoint may not be live yet, but the MVP
+ * requires submitted applications to be visible in an admin/backoffice stub.
+ * localStorage is authoritative for the stub; the backend is called opportunistically.
+ */
+
+export type LoanApplicationStatus =
+  | 'pending'
+  | 'submitted'
+  | 'approved'
+  | 'rejected';
+
+export interface StoredLoanApplication {
+  id: string;
+  productId: string;
+  productName: string;
+  amount: number;
+  term: number;
+  purpose?: string;
+  applicantUser?: string;
+  status: LoanApplicationStatus;
+  syncedWithBackend: boolean;
+  submittedAt: string;
+  errorMessage?: string;
+}
+
+const STORAGE_KEY = 'acbu:lending:applications';
+
+function hasWindow(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+export function listApplications(): StoredLoanApplication[] {
+  if (!hasWindow()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((a): a is StoredLoanApplication =>
+      !!a && typeof a === 'object' && typeof (a as StoredLoanApplication).id === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function saveApplication(app: StoredLoanApplication): StoredLoanApplication[] {
+  if (!hasWindow()) return [];
+  const current = listApplications();
+  const next = [app, ...current.filter((a) => a.id !== app.id)];
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  return next;
+}
+
+export function updateApplicationStatus(
+  id: string,
+  status: LoanApplicationStatus
+): StoredLoanApplication[] {
+  if (!hasWindow()) return [];
+  const current = listApplications();
+  const next = current.map((a) => (a.id === id ? { ...a, status } : a));
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  return next;
+}


### PR DESCRIPTION
# feat(lending): loan application intake + backoffice stub

Closes #189

## Summary

Adds the missing loan intake flow for MVP. `/lending` was a dead route with
only an API client stub — users had no way to apply for a loan, and there
was no surface for reviewers to verify that submissions were captured.

This PR introduces:

- A full intake page at `/lending` (product selection, validated form, live
  applications list).
- A backoffice stub at `/lending/admin` where submitted applications are
  visible with Approve / Reject controls.
- A small local persistence layer that makes the stub reliable even before
  the backend `/lending/apply` endpoint is live, while still calling the
  real API opportunistically so the wiring flips on automatically once the
  server ships.
- A `Lending` tile on the home dashboard so the feature is discoverable.

## Why

The issue flagged: *No loan intake for MVP. Fix direction: Create lending
application API + form. Acceptance check: Submitted application visible in
admin/backoffice stub.*

The API client (`applyForLoan` in [lib/api/lending.ts](lib/api/lending.ts))
already exposed `POST /lending/apply`, but there was no UI driving it and
no reviewer-facing view. The backend endpoint is still in flight, so the
acceptance check needed a path that works today without blocking on the
server.

## Changes

### New

- **[lib/lending-store.ts](lib/lending-store.ts)** — `localStorage`-backed
  persistence for submitted applications (`listApplications`,
  `saveApplication`, `updateApplicationStatus`). Defensive JSON parsing
  with a type guard so stale/garbage entries can't crash the page. The
  store is authoritative for the backoffice stub; the backend call is best
  effort.

- **[app/lending/page.tsx](app/lending/page.tsx)** — intake page.
  - Lender position card wired to `lendingApi.getLendingBalance`, keyed off
    the user's `pay_uri` from `userApi.getReceive` (same pattern as
    [app/savings/page.tsx](app/savings/page.tsx)).
  - Three loan products (Personal / Business / Emergency) with per-product
    amount and term bounds, surfaced in the UI and enforced at submit time.
  - Form fields: amount (ACBU), term (months), purpose (optional, 500 char
    cap). Client-side validation gates the submit button and returns a
    specific error if bounds are violated.
  - `handleSubmit` calls `lendingApi.applyForLoan({ productId, amount, term })`.
    On success the returned `loanId` is stored with `status: 'submitted'`
    and `syncedWithBackend: true`. On failure (e.g. endpoint not yet live)
    the record is still saved locally with a generated id, `status: 'pending'`,
    and the sync error captured in `errorMessage` — user sees a
    "Pending backend sync" banner rather than a silent drop.
  - "Your applications" list below the form renders the 5 most recent
    entries from the store with status badge.
  - Header link to `/lending/admin`.

- **[app/lending/admin/page.tsx](app/lending/admin/page.tsx)** — backoffice
  stub.
  - Header counters: pending-review count, total approved ACBU.
  - Full list of every submission with product, amount, term, applicant,
    submitted-at, reference, purpose, and a `synced` / `local` badge so a
    reviewer can tell at a glance whether the backend accepted it.
  - Approve / Reject buttons on pending/submitted rows, persisted back to
    the store via `updateApplicationStatus`.
  - Refresh button re-reads the store (useful across tabs).

### Modified

- **[app/page.tsx](app/page.tsx)** — added a `Lending` tile
  (HandCoins icon, orange) to the home feature grid so the route is
  discoverable from the dashboard.

## Acceptance check

The issue's acceptance check: *Submitted application visible in
admin/backoffice stub.*

1. Go to `/lending` (or tap the Lending tile on home).
2. Pick a product, enter a valid amount + term, submit.
3. Confirmation banner appears; the new record shows up in "Your
   applications" immediately.
4. Open `/lending/admin` (header link or the "View all" link under the
   list) — the submission is present with all metadata, and Approve /
   Reject updates the status in place.

Works regardless of whether the backend `/lending/apply` endpoint is live:
if it is, the record is marked `synced`; if not, it's marked `local` and
the sync error is shown on the admin card.

## Design notes

- **Why localStorage instead of waiting for the backend.** The issue's
  acceptance check is UI-visibility of submitted applications, and the
  backend endpoint is still being built. A local store lets the flow ship
  today, keeps the reviewer-facing stub honest (nothing is faked — every
  card reflects a real submission), and costs nothing to remove: when the
  server ships, the admin page swaps `listApplications()` for a server
  fetch.
- **Why the submit path doesn't fail hard on API error.** The same record
  is useful to the backoffice regardless of sync state, and surfacing a
  hard failure would block the MVP demo. The sync status and error
  message are surfaced in the admin view so nothing is hidden.
- **Bounds are product-driven, not hardcoded in the form.** Each
  `LoanProduct` owns its `min/maxAmount` and `min/maxTerm`, and the form
  rereads them via `useMemo(selectedProduct)`. Adding a new product is a
  single array entry.

## Risk / blast radius

- Purely additive — two new routes, one new lib file, one 2-line change to
  `app/page.tsx` to add the tile. No existing route, API client, or type
  is modified.
- No new dependencies.
- `localStorage` is client-only and guarded by a `hasWindow()` check, so
  SSR rendering of either page is safe.

## Test plan

- [ ] `/lending` renders with three product cards and lender position
      (loads balance when signed in, shows "Sign in to view" otherwise).
- [ ] Selecting each product updates the amount/term placeholders and
      validation bounds.
- [ ] Submitting below `minAmount`, above `maxAmount`, below `minTerm`, or
      above `maxTerm` shows the inline error and keeps the button
      disabled.
- [ ] Valid submit with backend reachable → success banner, record
      appears in "Your applications" with `submitted` status, and in
      `/lending/admin` tagged `synced`.
- [ ] Valid submit with backend unreachable (e.g. endpoint 404) → warning
      banner, record still appears locally with `pending` status and
      tagged `local` in admin, `errorMessage` visible on the admin card.
- [ ] Approve / Reject on the admin page updates status in place and
      survives a page reload.
- [ ] Home dashboard shows the `Lending` tile and routes to `/lending`.
- [ ] SSR: hard-reload of `/lending` and `/lending/admin` does not throw
      (no unguarded `window`/`localStorage` access).

## Follow-ups (not in this PR)

- When `POST /lending/apply` ships server-side, keep the client as-is —
  submissions will automatically be marked `synced`.
- Replace the local store in `/lending/admin` with a server list endpoint
  once the backend exposes one; the page shape doesn't need to change.
- Role-gate `/lending/admin` behind an admin claim (today any authenticated
  user can reach it; it's a stub, not a production surface).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive lending application system with a dedicated lending page for users to apply for loans with product selection, amount, and term inputs
  * Introduced lending admin interface for reviewing and managing loan applications with approve/reject functionality
  * Added application tracking with status badges (pending, submitted, approved, rejected) and sync indicators
  * Integrated lending feature into the home dashboard for easy access
  * Implemented local application history to maintain submitted loan applications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->