### PR TITLE
F-017: Fix SME CTA route and activate application mailto flow

### DIFF
--- a/app/business/page.tsx
+++ b/app/business/page.tsx
@@ -12,7 +12,7 @@ import * as businessApi from '@/lib/api/business';
 import type { BusinessStatsResponse } from '@/lib/api/business';
 
 const businessServices = [
-  { id: 'sme', title: 'SME Services', description: 'Business accounts, transfers & statements', icon: Briefcase, badge: 'Pro', href: '/sme' },
+  { id: 'sme', title: 'SME Services', description: 'Business accounts, transfers & statements', icon: Briefcase, badge: 'Pro', href: '/business/sme' },
   { id: 'salary', title: 'Payroll', description: 'Disburse salaries and manage batches', icon: Users, badge: 'New', href: '/salary' },
   { id: 'campaigns', title: 'Crowdfunding', description: 'Raise funds for projects via Trivela', icon: Zap, badge: 'Alpha', href: '/campaigns/1' },
   { id: 'enterprise', title: 'Enterprise', description: 'Bulk transfers and treasury management', icon: PiggyBank, href: '/enterprise' },

--- a/app/business/sme/page.tsx
+++ b/app/business/sme/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { PageContainer } from '@/components/layout/page-container';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, Briefcase, Mail, ArrowRight } from 'lucide-react';
+
+export default function SmePage() {
+  const smeEmail = 'sme@acbu.io';
+  const subject = encodeURIComponent('SME Services Inquiry from ACBU App');
+  const body = encodeURIComponent(
+    'I am interested in SME services. Please contact me to start the application process.\n\nSource: /business/sme'
+  );
+  const mailtoLink = `mailto:${smeEmail}?subject=${subject}&body=${body}`;
+
+  return (
+    <>
+      <div className="border-b border-border bg-card/95 backdrop-blur-sm sticky top-0 z-10">
+        <div className="px-4 py-3 flex items-center gap-3">
+          <Link href="/business" className="text-primary">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <div>
+            <h1 className="text-lg font-bold text-foreground">SME Services</h1>
+            <p className="text-sm text-muted-foreground">Apply for business banking, transfers, and statements.</p>
+          </div>
+        </div>
+      </div>
+
+      <PageContainer>
+        <Card className="border-border p-6 space-y-4">
+          <div className="flex items-start gap-4">
+            <div className="rounded-2xl bg-secondary p-3">
+              <Briefcase className="w-6 h-6 text-primary" />
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold text-foreground">SME onboarding</h2>
+              <p className="text-sm text-muted-foreground">
+                Get started with ACBU SME services for business accounts, transfers, and cash management.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            <Card className="border-border p-4 bg-background">
+              <h3 className="text-sm font-medium text-foreground">What you can do</h3>
+              <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                <li>• Open a business account</li>
+                <li>• Manage SME transfers</li>
+                <li>• Access statements and reporting</li>
+              </ul>
+            </Card>
+
+            <Button className="w-full justify-between" asChild>
+              <a href={mailtoLink} className="flex items-center justify-between gap-3">
+                <span>Apply for SME services</span>
+                <Mail className="w-4 h-4" />
+              </a>
+            </Button>
+
+            <div className="flex items-center justify-between rounded-lg border border-border bg-muted p-4 text-sm text-muted-foreground">
+              <span>Application route</span>
+              <span className="text-foreground">mailto:{smeEmail}</span>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Tracking source:</span>
+            <span className="font-mono text-foreground">/business/sme</span>
+          </div>
+        </Card>
+      </PageContainer>
+    </>
+  );
+}


### PR DESCRIPTION
Title: F-017: Fix SME CTA route and activate application mailto flow

Body:
- Fixed the SME card route so it navigates to `/business/sme`
- Added a working SME application page at `/business/sme`
- Activated the CTA button with a real tracked `mailto:` flow
- Included source tracking text in the email body for analytics
- Prevented the previous lead-gen dead end on the SME page

Closes #188