### PR TITLE
fix(auth): remove URL fallback for 2FA challenge token

### DIFF
--- a/app/auth/2fa/page.tsx
+++ b/app/auth/2fa/page.tsx
@@ -33,6 +33,7 @@ function TwoFactorForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [challengeToken, setChallengeToken] = useState('');
+  const [checked, setChecked] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -40,6 +41,7 @@ function TwoFactorForm() {
     if (storedToken) {
       setChallengeToken(storedToken);
     }
+    setChecked(true);
   }, []);
 
   const handleVerify = async (e: React.FormEvent) => {
@@ -120,7 +122,7 @@ function TwoFactorForm() {
             </Button>
           </form>
 
-          {!challengeToken && (
+          {checked && !challengeToken && (
             <p className="mt-4 text-sm text-destructive">
               Missing challenge token.{" "}
               <Link href="/auth/signin" className="underline">

--- a/app/auth/2fa/page.tsx
+++ b/app/auth/2fa/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, Suspense } from 'react';
-import { useRouter, useSearchParams} from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -28,49 +28,37 @@ export default function TwoFactorPage() {
 
 function TwoFactorForm() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { login } = useAuth();
   const [code, setCode] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [challengeToken, setChallengeToken] = useState('');
 
-  // Retrieve challenge token from sessionStorage (not from URL)
-  // This prevents exposure via Referer headers, browser history, and server logs
   useEffect(() => {
     if (typeof window === "undefined") return;
-
-    const urlToken = searchParams.get("challenge_token");
     const storedToken = sessionStorage.getItem(CHALLENGE_TOKEN_KEY);
-
-    if (urlToken) {
-      sessionStorage.setItem(CHALLENGE_TOKEN_KEY, urlToken);
-      setChallengeToken(urlToken);
-
-      router.replace("/auth/2fa", { scroll: false });
-    } else if (storedToken) {
+    if (storedToken) {
       setChallengeToken(storedToken);
     }
-  }, [searchParams, router]);
+  }, []);
 
-    const handleVerify = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setError("");
-        setLoading(true);
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
 
-        try {
-            if (!code || code.length !== 6) {
-                setError("Please enter a valid 6-digit code");
-                return;
-            }
-            if (!challengeToken) {
-                setError("Missing challenge. Please sign in again.");
-                return;
-            }
+    try {
+      if (!code || code.length !== 6) {
+        setError("Please enter a valid 6-digit code");
+        return;
+      }
+      if (!challengeToken) {
+        setError("Missing challenge. Please sign in again.");
+        return;
+      }
 
       const result = await authApi.verify2fa(challengeToken, code);
       login(result.api_key!, result.user_id, result.stellar_address);
-      // Clear challenge token from sessionStorage
       sessionStorage.removeItem(CHALLENGE_TOKEN_KEY);
       router.push('/');
     } catch (err) {
@@ -80,88 +68,82 @@ function TwoFactorForm() {
     }
   };
 
-    return (
-        <div className="min-h-screen bg-background flex items-center justify-center p-4">
-            <Card className="w-full max-w-md border-border">
-                <div className="p-6 md:p-8">
-                    <div className="mb-8">
-                        <h1 className="text-2xl md:text-3xl font-bold text-foreground mb-2">
-                            Two-Factor Authentication
-                        </h1>
-                        <p className="text-sm text-muted-foreground">
-                            Enter the 6-digit code from your authenticator app
-                        </p>
-                    </div>
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="w-full max-w-md border-border">
+        <div className="p-6 md:p-8">
+          <div className="mb-8">
+            <h1 className="text-2xl md:text-3xl font-bold text-foreground mb-2">
+              Two-Factor Authentication
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Enter the 6-digit code from your authenticator app
+            </p>
+          </div>
 
-                    <form onSubmit={handleVerify} className="space-y-4">
-                        {error && (
-                            <div className="flex gap-3 p-3 rounded-lg border border-destructive/30 bg-destructive/10">
-                                <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0 mt-0.5" />
-                                <p className="text-sm text-destructive">
-                                    {error}
-                                </p>
-                            </div>
-                        )}
+          <form onSubmit={handleVerify} className="space-y-4">
+            {error && (
+              <div className="flex gap-3 p-3 rounded-lg border border-destructive/30 bg-destructive/10">
+                <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-destructive">{error}</p>
+              </div>
+            )}
 
-                        <div>
-                            <label
-                                htmlFor="auth-code"
-                                className="text-sm font-medium text-foreground mb-2 block"
-                            >
-                                Authentication Code
-                            </label>
-                            <Input
-                                id="auth-code"
-                                type="text"
-                                placeholder="000000"
-                                value={code}
-                                onChange={(e) =>
-                                    setCode(
-                                        e.target.value
-                                            .replace(/\D/g, "")
-                                            .slice(0, 6),
-                                    )
-                                }
-                                maxLength={6}
-                                className="border-border text-center text-lg font-mono tracking-widest"
-                                disabled={loading}
-                                autoFocus
-                            />
-                        </div>
+            <div>
+              <label
+                htmlFor="auth-code"
+                className="text-sm font-medium text-foreground mb-2 block"
+              >
+                Authentication Code
+              </label>
+              <Input
+                id="auth-code"
+                type="text"
+                placeholder="000000"
+                value={code}
+                onChange={(e) =>
+                  setCode(e.target.value.replace(/\D/g, "").slice(0, 6))
+                }
+                maxLength={6}
+                className="border-border text-center text-lg font-mono tracking-widest"
+                disabled={loading}
+                autoFocus
+              />
+            </div>
 
-                        <Button
-                            type="submit"
-                            className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
-                            disabled={loading}
-                        >
-                            {loading ? "Verifying..." : "Verify"}
-                        </Button>
-                    </form>
+            <Button
+              type="submit"
+              className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
+              disabled={loading}
+            >
+              {loading ? "Verifying..." : "Verify"}
+            </Button>
+          </form>
 
-                    {!challengeToken && (
-                        <p className="mt-4 text-sm text-destructive">
-                            Missing challenge token.{" "}
-                            <Link href="/auth/signin" className="underline">
-                                Sign in again
-                            </Link>
-                            .
-                        </p>
-                    )}
-                    <div className="mt-6">
-                        <div className="border-t border-border pt-4">
-                            <details className="text-sm">
-                                <summary className="cursor-pointer text-muted-foreground hover:text-foreground font-medium">
-                                    Don't have access to your authenticator?
-                                </summary>
-                                <p className="mt-2 text-muted-foreground">
-                                    Contact support or use your backup codes if
-                                    you saved them.
-                                </p>
-                            </details>
-                        </div>
-                    </div>
-                </div>
-            </Card>
+          {!challengeToken && (
+            <p className="mt-4 text-sm text-destructive">
+              Missing challenge token.{" "}
+              <Link href="/auth/signin" className="underline">
+                Sign in again
+              </Link>
+              .
+            </p>
+          )}
+
+          <div className="mt-6">
+            <div className="border-t border-border pt-4">
+              <details className="text-sm">
+                <summary className="cursor-pointer text-muted-foreground hover:text-foreground font-medium">
+                  Don't have access to your authenticator?
+                </summary>
+                <p className="mt-2 text-muted-foreground">
+                  Contact support or use your backup codes if you saved them.
+                </p>
+              </details>
+            </div>
+          </div>
         </div>
-    );
+      </Card>
+    </div>
+  );
 }


### PR DESCRIPTION
## Problem
The 2FA page contained a fallback that read the challenge token 
directly from the URL query param (`?challenge_token=...`). Even 
though the signin flow was already setting the token in sessionStorage, 
this fallback kept the old leak surface alive — the token would still 
appear in server access logs, Referer headers, and browser history on 
any request that used the URL path.

## Fix
- Removed `useSearchParams` and the `urlToken` fallback entirely
- The 2FA page now reads the challenge token exclusively from 
  sessionStorage, which is set by the signin flow before redirecting
- Removed the `router.replace` call that was used to clean the URL 
  after reading from it (no longer needed)

## Acceptance
- Token never appears in the URL bar
- Token never appears in server access logs
- sessionStorage entry is cleared immediately after successful verification

Closes #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced two-factor authentication security and reliability through improved token handling during the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->