### PR TITLE
fix(copy): replace AFK with ACBU via single currency constant

### DIFF
--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -22,6 +22,7 @@ import { Zap,
     AlertCircle,
 } from "lucide-react";
 import { formatAmount } from "@/lib/utils";
+import { CURRENCY } from "@/lib/currency";
 
 interface BillProvider {
     id: string;
@@ -227,7 +228,7 @@ export default function BillsPage() {
                                                     {formatAmount(
                                                         provider.minAmount,
                                                     )}{" "}
-                                                    - AFK{" "}
+                                                    - {CURRENCY}{" "}
                                                     {formatAmount(
                                                         provider.maxAmount,
                                                     )}
@@ -266,7 +267,7 @@ export default function BillsPage() {
                                                     <CheckCircle className="w-4 h-4 text-green-600" />
                                                 )}
                                                 <p className="font-semibold text-foreground">
-                                                    -AFK{" "}
+                                                    -{CURRENCY}{" "}
                                                     {formatAmount(tx.amount)}
                                                 </p>
                                             </div>

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,0 +1,2 @@
+/** Canonical display symbol for the native currency. Use this everywhere in UI strings. */
+export const CURRENCY = 'ACBU';


### PR DESCRIPTION
- Add lib/currency.ts exporting CURRENCY = 'ACBU' as the canonical symbol
- Fix two user-visible AFK strings in app/bills/page.tsx (min/max range label and history transaction amount) to use the constant
- No other changes

Closes #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized currency symbol display across the Bills page using a centralized configuration, ensuring consistent presentation of currency values in both the catalog and transaction history sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->