### PR TITLE
security: implement strict Content-Security-Policy with nonces

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import type { Metadata, Viewport } from 'next'
+import { headers } from 'next/headers'
 import { Analytics } from '@vercel/analytics/next'
 import { AuthProvider } from '@/contexts/auth-context'
 import { ErrorBoundary } from '@/components/error-boundary'
@@ -43,6 +44,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const nonce = (await headers()).get('x-nonce') || undefined;
   const lang = "en";
 
   return (
@@ -55,7 +57,7 @@ export default async function RootLayout({
             {/*</AuthGuard>*/}
             <WalletSetupModal />
             <Toaster />
-            <Analytics />
+            <Analytics nonce={nonce} />
           </AuthProvider>
         </ErrorBoundary>
       </body>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+  
+  const isDev = process.env.NODE_ENV === 'development';
+  
+  // Define CSP directives
+  // Using strict-dynamic with nonces for scripts
+  // style-src includes nonce for styled-components or similar if used
+  const cspDirectives = {
+    'default-src': ["'self'"],
+    'script-src': [
+      "'self'",
+      `'nonce-${nonce}'`,
+      "'strict-dynamic'",
+      isDev ? "'unsafe-eval'" : "",
+    ].filter(Boolean),
+    'style-src': ["'self'", `'nonce-${nonce}'`, "'unsafe-inline'"], // unsafe-inline often needed for Next.js internal styles
+    'img-src': ["'self'", "blob:", "data:", "https://*"], // Allow external images
+    'font-src': ["'self'"],
+    'object-src': ["'none'"],
+    'base-uri': ["'self'"],
+    'form-action': ["'self'"],
+    'frame-ancestors': ["'none'"],
+    'connect-src': [
+      "'self'", 
+      "https://*.stellar.org", 
+      "https://*.soroban-rpc.com",
+      "https://*.vercel-analytics.com",
+      isDev ? "ws://localhost:*" : ""
+    ].filter(Boolean),
+    'upgrade-insecure-requests': [],
+  };
+
+  const cspHeaderValue = Object.entries(cspDirectives)
+    .map(([key, values]) => {
+      if (values.length === 0) return key;
+      return `${key} ${values.join(' ')}`;
+    })
+    .join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  
+  // Start with Report-Only as per requirements
+  const headerName = process.env.CSP_ENFORCE === 'true' 
+    ? 'Content-Security-Policy' 
+    : 'Content-Security-Policy-Report-Only';
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  response.headers.set(headerName, cspHeaderValue);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
This PR implements a strict Content-Security-Policy using nonces in a Next.js middleware, addressing the security concerns raised in #235.

### Changes:
- **Middleware Integration**: Added `middleware.ts` to generate unique nonces for each request and inject them into the `Content-Security-Policy-Report-Only` header.
- **Strict Directives**: Implemented `strict-dynamic` for scripts to allow trusted scripts to load their dependencies without manual whitelisting.
- **Layout Support**: Updated `RootLayout` to retrieve the nonce from headers and pass it to Next.js components (e.g., Analytics).
- **Phased Rollout**: Initial implementation uses `Report-Only` mode to ensure no breakage before full enforcement.

Closes #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced application security with per-request nonce generation and Content Security Policy implementation to protect against injection attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->