### PR TITLE
fix: remove sessionStorage passcode, dedup auth header, gate bills, document SRI

### DIFF
--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+// F-020: Bills payment is gated behind NEXT_PUBLIC_BILLS_ENABLED.
+// When false (default), users see an honest "coming soon" screen instead of
+// a fake payment flow that only logs to the console.
+const BILLS_ENABLED = process.env.NEXT_PUBLIC_BILLS_ENABLED === "true";
+
 import React, { useState } from "react";
 import { PageContainer } from "@/components/layout/page-container";
 import { Input } from "@/components/ui/input";
@@ -151,6 +156,36 @@ export default function BillsPage() {
         setReference("");
         setSelectedProvider(null);
     };
+
+    // Feature flag gate — show honest copy instead of the stub flow (F-020).
+    if (!BILLS_ENABLED) {
+        return (
+            <div className="pb-20">
+                <div className="px-4 pt-6 pb-6 border-b border-border">
+                    <h1 className="text-2xl font-bold text-foreground mb-2">
+                        Bills
+                    </h1>
+                    <p className="text-sm text-muted-foreground">
+                        Pay bills and subscriptions easily
+                    </p>
+                </div>
+                <PageContainer>
+                    <Card className="border-border p-8 flex flex-col items-center text-center gap-4 mt-6">
+                        <Zap className="w-10 h-10 text-muted-foreground" />
+                        <div>
+                            <h2 className="text-lg font-semibold text-foreground mb-1">
+                                Coming soon
+                            </h2>
+                            <p className="text-sm text-muted-foreground max-w-xs">
+                                Bill payments are not yet available. We&apos;ll
+                                notify you when this feature launches.
+                            </p>
+                        </div>
+                    </Card>
+                </PageContainer>
+            </div>
+        );
+    }
 
     return (
         <>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,6 +57,23 @@ export default async function RootLayout({
             {/*</AuthGuard>*/}
             <WalletSetupModal />
             <Toaster />
+            {/*
+              F-065 SRI review: the only third-party script injected here is
+              @vercel/analytics/next, which is bundled at build time (first-party,
+              no external CDN fetch). The nonce above is forwarded so it passes
+              the strict-dynamic CSP set in middleware.ts.
+
+              If any external CDN scripts (<Script src="https://..."/>) are added
+              in the future, they MUST include integrity + crossOrigin="anonymous"
+              attributes, e.g.:
+                <Script
+                  src="https://cdn.example.com/lib.js"
+                  integrity="sha384-<hash>"
+                  crossOrigin="anonymous"
+                  nonce={nonce}
+                />
+              SRI hashes can be generated at https://www.srihash.org/
+            */}
             <Analytics nonce={nonce} />
           </AuthProvider>
         </ErrorBoundary>

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -92,8 +92,10 @@ async function request<T>(
 
   const token = opts.token !== undefined ? opts.token : currentToken;
   if (token) {
+    // Send only the Authorization header per backend contract.
+    // The former x-api-key duplicate has been removed to eliminate the redundant
+    // secret channel that could surface in proxy logs (F-007).
     headers['Authorization'] = `Bearer ${token}`;
-    headers['x-api-key'] = token; // Also send as x-api-key for compatibility
   }
 
   let signal = opts.signal;

--- a/lib/wallet-storage.ts
+++ b/lib/wallet-storage.ts
@@ -8,7 +8,11 @@ localforage.config({
 const KEY_STORE_PREFIX = 'stellar_secret_';
 const KEY_STORE_PLAINTEXT_PREFIX = 'stellar_secret_plain_';
 const KEY_STORE_PLAINTEXT_ADDRESS_PREFIX = 'stellar_secret_plain_addr_';
-const KEY_STORE_PASSPHRASE = 'acbu_passcode';
+// KEY_STORE_PASSPHRASE intentionally removed (F-003):
+// The passcode must never be persisted in sessionStorage — it must only live
+// in memory for the duration of a single decrypt operation.  Any caller that
+// previously relied on the sessionStorage round-trip must pass the passcode
+// explicitly as a function argument instead.
 
 function assertDevOnly(): void {
   if (process.env.NODE_ENV === 'production') {
@@ -122,30 +126,19 @@ export async function getWalletSecretLocalPlaintext(
 }
 
 /**
- * Best-effort wallet secret lookup:
- * - plaintext slot (dev/test flows and wallet-setup modal)
- * - encrypted slot decrypted with passcode from sessionStorage (wallet page flow)
+ * Best-effort wallet secret lookup (dev/test flows only).
+ *
+ * Returns the plaintext secret from the dev storage slot.
+ * The former sessionStorage passcode path has been intentionally removed (F-003):
+ * passcodes must be held in memory only and passed explicitly to `getWalletSecret()`
+ * by callers that perform authenticated decryption.
  */
 export async function getWalletSecretAnyLocal(
   userId: string,
   stellarAddress?: string | null,
 ): Promise<string | null> {
   assertDevOnly();
-  const plaintext = await getWalletSecretLocalPlaintext(userId, stellarAddress);
-  if (plaintext) return plaintext;
-
-  try {
-    if (typeof window !== 'undefined') {
-      const passcode = window.sessionStorage.getItem(KEY_STORE_PASSPHRASE) || '';
-      if (passcode) {
-        const decrypted = await getWalletSecret(userId, passcode);
-        if (decrypted) return decrypted;
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return null;
+  return getWalletSecretLocalPlaintext(userId, stellarAddress);
 }
 
 export async function hasStoredWallet(userId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

- Fixes #174 (F-003 — Critical) **Passcode stored in sessionStorage**: removed `KEY_STORE_PASSPHRASE` constant and the `window.sessionStorage.getItem(KEY_STORE_PASSPHRASE)` call inside `getWalletSecretAnyLocal()` in `lib/wallet-storage.ts`. The function now returns only the dev-plaintext slot. Callers that need authenticated decryption must pass the passcode explicitly to `getWalletSecret(userId, passcode)` — it must never be persisted outside memory.

- Fixes #178 (F-007 — Medium) **Dual Authorization + x-api-key headers**: removed the redundant `headers['x-api-key'] = token` line from `lib/api/client.ts`. Only `Authorization: Bearer <token>` is sent per the backend contract. Eliminates the second secret channel that would appear in proxy logs on every request.

- Fixes #191 (F-020 — High) **Bills payment console-only / fake flow**: added a `NEXT_PUBLIC_BILLS_ENABLED` feature flag (default `false`) at the top of `app/bills/page.tsx`. When the flag is off, the component renders an honest **"Coming soon"** card rather than the stub payment dialog that settled to a `setTimeout` and a console log. Set `NEXT_PUBLIC_BILLS_ENABLED=true` in `.env.local` to re-enable the existing UI during development while the real bills endpoints are being built.

- Fixes #236 (F-065 — Low) **No Subresource Integrity for third-party scripts**: added an inline SRI review comment next to `<Analytics nonce={nonce} />` in `app/layout.tsx` confirming the only injected script is the first-party `@vercel/analytics` package (bundled at build time, no external CDN fetch) and that the nonce is already forwarded through the strict-dynamic CSP in `middleware.ts`. The comment also provides the canonical template for adding `integrity` + `crossOrigin="anonymous"` attributes to any future external `<Script>` tags.

## Checklist

| # | Acceptance | Status |
|---|-----------|--------|
| #174 | Passcode only in memory during operation — no sessionStorage persistence | ✅ Removed |
| #178 | Proxy logs never contain duplicate secret lines | ✅ Single header only |
| #191 | Feature flag off shows honest copy | ✅ "Coming soon" when `NEXT_PUBLIC_BILLS_ENABLED` ≠ `"true"` |
| #236 | Security review checklist: SRI posture documented | ✅ Comment in layout.tsx |

**TypeScript:** `tsc --noEmit` → 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-controlled feature flag to toggle bills payment functionality on/off

* **Bug Fixes**
  * Simplified API client authorization header handling

* **Improvements**
  * Streamlined wallet secret retrieval process

* **Documentation**
  * Added documentation for analytics script and content security policy requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->