### PR TITLE
Fix savings URI resolution, reserves unit labels, and wallet secret encryption

### DIFF
--- a/app/reserves/page.tsx
+++ b/app/reserves/page.tsx
@@ -83,8 +83,8 @@ export default function ReservesPage() {
             <Card className="border-border p-4 space-y-3">
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
-                  <MetricLabel label="Total reserves" tip="On-chain USD value of all backing assets, stored as 7-decimal fixed-point integers." />
-                  <span className="text-xs text-muted-foreground">On-chain USD value (7-dec fixed).</span>
+                  <MetricLabel label="Total reserves (USD)" tip="On-chain USD value of all backing assets, stored as 7-decimal fixed-point integers." />
+                  <span className="text-xs text-muted-foreground">USD value at 7-decimal fixed precision.</span>
                 </div>
                 <div className="flex flex-col items-end">
                   <span className="font-medium">
@@ -97,7 +97,7 @@ export default function ReservesPage() {
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
                   <MetricLabel label="Total ACBU supply" tip="Total ACBU tokens in circulation, tracked by the minting contract." />
-                  <span className="text-xs text-muted-foreground">Minting contract tracked supply.</span>
+                  <span className="text-xs text-muted-foreground">ACBU tokens in circulation.</span>
                 </div>
                 <div className="flex flex-col items-end">
                   <span className="font-medium">
@@ -108,8 +108,8 @@ export default function ReservesPage() {
 
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
-                  <MetricLabel label="Collateral ratio" tip="Reserves ÷ ACBU supply in USD terms. Must stay above the minimum ratio to remain solvent." />
-                  <span className="text-xs text-muted-foreground">Reserves ÷ supply (USD terms).</span>
+                  <MetricLabel label="Collateral ratio (×)" tip="Total reserves divided by total ACBU supply in USD terms. Expressed as a multiplier." />
+                  <span className="text-xs text-muted-foreground">Reserves ÷ supply, shown as a multiplier.</span>
                 </div>
                 <div className="flex flex-col items-end">
                   <span className="font-medium">
@@ -123,8 +123,8 @@ export default function ReservesPage() {
 
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col">
-                  <MetricLabel label="Health" tip="Issuer-reported reserve health status. Reflects whether collateral ratio and weight compliance are within acceptable bounds." />
-                  <span className="text-xs text-muted-foreground">Issuer-reported status.</span>
+                  <MetricLabel label="Health" tip="Issuer-reported reserve health status. Indicates whether collateral ratio and weight compliance are within acceptable bounds." />
+                  <span className="text-xs text-muted-foreground">Issuer-reported health status.</span>
                 </div>
                 <div className="flex flex-col items-end">
                   <span className="font-medium">{data.health || '—'}</span>
@@ -172,23 +172,23 @@ export default function ReservesPage() {
 
                     <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
                       <div className="flex flex-col">
-                        <MetricLabel label="Balance" tip="Raw on-chain balance of this currency in the reserve pool." />
+                        <MetricLabel label="Balance" tip="Raw on-chain amount of this currency held in the reserve pool." />
                         <span className="text-foreground">
                           {formatAmount(fixed7ToNumber(c.amount), 2)} {c.currency}
                         </span>
                       </div>
                       <div className="flex flex-col items-end">
-                        <MetricLabel label="USD value" tip="Balance converted to USD at the current oracle rate." />
+                        <MetricLabel label="USD value" tip="Currency balance converted to USD using the current oracle exchange rate." />
                         <span className="text-foreground">
                           USD {formatAmount(fixed7ToNumber(c.value_usd), 2)}
                         </span>
                       </div>
                       <div className="flex flex-col">
-                        <MetricLabel label="Target" tip="Desired portfolio weight for this currency (basis points ÷ 100 = %)." />
+                        <MetricLabel label="Target" tip="Desired portfolio weight for this currency, expressed in basis points (÷100 = %)." />
                         <span className="text-foreground">{formatPct(c.target_weight_bps)}</span>
                       </div>
                       <div className="flex flex-col items-end">
-                        <MetricLabel label="Actual" tip="Current portfolio weight. Drift from target triggers a warning when outside the allowed threshold." />
+                        <MetricLabel label="Actual" tip="Current portfolio weight, expressed in basis points. Drift from target triggers warnings beyond the allowed threshold." />
                         <span className="text-foreground">{formatPct(c.actual_weight_bps)}</span>
                       </div>
                     </div>

--- a/app/savings/deposit/page.tsx
+++ b/app/savings/deposit/page.tsx
@@ -10,7 +10,20 @@ import { ArrowLeft } from "lucide-react";
 import { useApiOpts } from "@/hooks/use-api";
 import * as userApi from "@/lib/api/user";
 import * as savingsApi from "@/lib/api/savings";
+import { resolveRecipient } from "@/lib/api/recipient";
 import { logger } from "@/lib/logger";
+
+async function resolveUserUri(
+  raw: string,
+  opts: Parameters<typeof resolveRecipient>[1],
+): Promise<string> {
+  try {
+    const resolved = await resolveRecipient(raw, opts);
+    return resolved.pay_uri ?? resolved.alias ?? raw;
+  } catch {
+    return raw;
+  }
+}
 
 export default function SavingsDepositPage() {
     const opts = useApiOpts();
@@ -22,12 +35,18 @@ export default function SavingsDepositPage() {
     const [success, setSuccess] = useState("");
 
   useEffect(() => {
-    userApi.getReceive(opts).then((data) => {
+    let cancelled = false;
+    userApi.getReceive(opts).then(async (data) => {
       const uri = (data.pay_uri ?? data.alias) as string | undefined;
-      if (uri && typeof uri === 'string') setUser(uri);
+      if (!uri || typeof uri !== 'string') return;
+      const resolved = await resolveUserUri(uri, opts);
+      if (!cancelled) setUser(resolved);
     }).catch((e) => {
       logger.error(e instanceof Error ? e.message : 'Failed to load receive address');
+    }).finally(() => {
+      if (cancelled) return;
     });
+    return () => { cancelled = true; };
   }, [opts.token]);
 
     const handleSubmit = async (e: React.FormEvent) => {

--- a/app/savings/withdraw/page.tsx
+++ b/app/savings/withdraw/page.tsx
@@ -10,7 +10,20 @@ import { ArrowLeft } from "lucide-react";
 import { useApiOpts } from "@/hooks/use-api";
 import * as userApi from "@/lib/api/user";
 import * as savingsApi from "@/lib/api/savings";
+import { resolveRecipient } from "@/lib/api/recipient";
 import { logger } from "@/lib/logger";
+
+async function resolveUserUri(
+  raw: string,
+  opts: Parameters<typeof resolveRecipient>[1],
+): Promise<string> {
+  try {
+    const resolved = await resolveRecipient(raw, opts);
+    return resolved.pay_uri ?? resolved.alias ?? raw;
+  } catch {
+    return raw;
+  }
+}
 
 export default function SavingsWithdrawPage() {
     const opts = useApiOpts();
@@ -22,12 +35,14 @@ export default function SavingsWithdrawPage() {
     const [success, setSuccess] = useState("");
 
     useEffect(() => {
+        let cancelled = false;
         userApi
             .getReceive(opts)
-            .then((data) => {
+            .then(async (data) => {
                 const uri = (data.pay_uri ?? data.alias) as string | undefined;
-                if (uri && typeof uri === "string")
-                    setUser(uri);
+                if (!uri || typeof uri !== "string") return;
+                const resolved = await resolveUserUri(uri, opts);
+                if (!cancelled) setUser(resolved);
             })
             .catch((e) => {
                 logger.error(
@@ -36,6 +51,7 @@ export default function SavingsWithdrawPage() {
                         : "Failed to load receive address",
                 );
             });
+        return () => { cancelled = true; };
     }, [opts.token]);
 
     const handleSubmit = async (e: React.FormEvent) => {

--- a/lib/wallet-storage.ts
+++ b/lib/wallet-storage.ts
@@ -10,32 +10,100 @@ const KEY_STORE_PREFIX = 'stellar_secret_';
 const KEY_STORE_PLAINTEXT_PREFIX = 'stellar_secret_plain_';
 const KEY_STORE_PLAINTEXT_ADDRESS_PREFIX = 'stellar_secret_plain_addr_';
 
-/**
- * Simulates AES encryption for the local storage.
- * In a production app, use SubtleCrypto or a library like 'crypto-js' to encrypt/decrypt
- * using the user's passcode or a derived key.
- */
-function encryptSecret(secret: string, passcode: string): string {
-  // Mock encryption: simple base64 encode with passcode for demo.
-  // DO NOT use this in real production without real AES encryption.
-  return btoa(`${passcode}:${secret}`);
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+const SALT_SIZE = 16;
+const IV_SIZE = 12;
+const PBKDF2_ITERATIONS = 200_000;
+
+function toBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer;
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
 }
 
-function decryptSecret(encrypted: string, passcode: string): string | null {
+function fromBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function deriveKey(passcode: string, salt: Uint8Array): Promise<CryptoKey> {
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    textEncoder.encode(passcode),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    baseKey,
+    {
+      name: 'AES-GCM',
+      length: 256,
+    },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+async function encryptSecret(secret: string, passcode: string): Promise<string> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_SIZE));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_SIZE));
+  const key = await deriveKey(passcode, salt);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    textEncoder.encode(secret),
+  );
+
+  return JSON.stringify({
+    version: 1,
+    salt: toBase64(salt),
+    iv: toBase64(iv),
+    ciphertext: toBase64(ciphertext),
+  });
+}
+
+async function decryptSecret(encrypted: string, passcode: string): Promise<string | null> {
   try {
-    const decoded = atob(encrypted);
-    const [p, secret] = decoded.split(':');
-    if (p === passcode) {
-      return secret;
-    }
-    return null;
+    const payload = JSON.parse(encrypted) as {
+      version: number;
+      salt: string;
+      iv: string;
+      ciphertext: string;
+    };
+    if (payload.version !== 1) return null;
+
+    const salt = fromBase64(payload.salt);
+    const iv = fromBase64(payload.iv);
+    const ciphertext = fromBase64(payload.ciphertext);
+    const key = await deriveKey(passcode, salt);
+    const decrypted = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      ciphertext,
+    );
+    return textDecoder.decode(decrypted);
   } catch {
     return null;
   }
 }
 
 export async function storeWalletSecret(userId: string, secret: string, passcode: string): Promise<void> {
-  const encrypted = encryptSecret(secret, passcode);
+  const encrypted = await encryptSecret(secret, passcode);
   await localforage.setItem(`${KEY_STORE_PREFIX}${userId}`, encrypted);
 }
 
@@ -43,7 +111,7 @@ export async function getWalletSecret(userId: string, passcode: string): Promise
   const encrypted = await localforage.getItem<string>(`${KEY_STORE_PREFIX}${userId}`);
   if (!encrypted) return null;
   
-  return decryptSecret(encrypted, passcode);
+  return await decryptSecret(encrypted, passcode);
 }
 
 /**


### PR DESCRIPTION
This PR fixes three frontend issues:

- Aligns savings deposit/withdraw with backend recipient resolution so non-Stellar identifiers work where supported.
- Adds unit and metric clarifications to the Reserves page for better comprehension.
- Replaces mock base64 wallet secret storage with AES-GCM using PBKDF2-derived keys.

 closes #212
closes #228 
closes #175