### PR TITLE
fix(a11y): add aria-labels to icon-only navigation links

### DIFF
--- a/app/me/profile/page.tsx
+++ b/app/me/profile/page.tsx
@@ -178,7 +178,7 @@ export default function ProfilePage() {
         return (
             <>
                 <div className="flex items-center gap-3 border-b border-border px-4 pb-6 pt-4">
-                    <Link href="/me">
+                    <Link href="/me" aria-label="Back to profile">
                         <ArrowLeft className="h-5 w-5 text-primary" />
                     </Link>
                     <h1 className="text-xl font-bold text-foreground">
@@ -197,7 +197,7 @@ export default function ProfilePage() {
         return (
             <>
                 <div className="flex items-center gap-3 border-b border-border px-4 pb-6 pt-4">
-                    <Link href="/me">
+                    <Link href="/me" aria-label="Back to profile">
                         <ArrowLeft className="h-5 w-5 text-primary" />
                     </Link>
                     <h1 className="text-xl font-bold text-foreground">
@@ -214,7 +214,7 @@ export default function ProfilePage() {
     return (
         <>
             <div className="flex items-center gap-3 border-b border-border px-4 pb-6 pt-4">
-                <Link href="/me">
+                <Link href="/me" aria-label="Back to profile">
                     <ArrowLeft className="h-5 w-5 text-primary hover:text-primary/80" />
                 </Link>
                 <h1 className="text-xl font-bold text-foreground">Profile</h1>

--- a/app/me/settings/page.tsx
+++ b/app/me/settings/page.tsx
@@ -22,7 +22,9 @@ export default function SettingsPage() {
     <>
       <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
         <div className="px-4 py-3 flex items-center gap-3">
-          <Link href="/me"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
+          <Link href="/me" aria-label="Back to profile">
+            <ArrowLeft className="w-5 h-5 text-primary" />
+          </Link>
           <h1 className="text-lg font-bold text-foreground">Settings</h1>
         </div>
       </div>


### PR DESCRIPTION
## Description

Adds accessible `aria-label` attributes to icon-only navigation links in the profile and settings pages to improve screen reader support.

## Related Issue

Closes #339

## Changes

- added `aria-label` to icon-only back navigation links
- improved accessibility for screen reader users
- kept changes minimal and isolated

## Testing

- verified icon-only links expose accessible labels
- verified no visual/layout changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved accessibility labels for "Back to profile" navigation links across profile and settings pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->