### PR TITLE
fix(currency): respect selected mint network preference

### DIFF
--- a/app/currency/page.tsx
+++ b/app/currency/page.tsx
@@ -23,7 +23,7 @@ import { useApiError } from "@/hooks/use-api-error";
 import { ApiErrorDisplay } from "@/components/ui/api-error-display";
 import * as mintApi from "@/lib/api/mint";
 import * as burnApi from "@/lib/api/burn";
-import type { MintResponse, BurnResponse } from "@/types/api";
+import type { MintResponse, BurnResponse, CurrencyPreference } from "@/types/api";
 import { logger } from "@/lib/logger";
 
 /** Local currency units per 1 ACBU from the `/rates` oracle, or null if missing. */
@@ -75,7 +75,7 @@ export default function CurrencyPage() {
 
   // Mint state
   const [mintAmount, setMintAmount] = useState("");
-  const [mintSource, setMintSource] = useState("usdc");
+  const [mintSource, setMintSource] = useState<Exclude<CurrencyPreference, "auto">>("usdc");
   const [mintWalletAddress, setMintWalletAddress] = useState("");
 
   // Burn state
@@ -138,7 +138,7 @@ export default function CurrencyPage() {
         const res: MintResponse = await mintApi.mintFromUsdc(
           mintAmount,
           mintWalletAddress.trim(),
-          "auto",
+          mintSource,
           opts,
         );
         setLastTxId(res.transaction_id);

--- a/lib/api/mint.ts
+++ b/lib/api/mint.ts
@@ -1,11 +1,11 @@
 import { post } from './client';
 import type { RequestOptions } from './client';
-import type { MintFromUsdcBody, MintResponse } from '@/types/api';
+import type { MintFromUsdcBody, MintResponse, CurrencyPreference } from '@/types/api';
 
 export async function mintFromUsdc(
   usdcAmount: string,
   walletAddress: string,
-  currencyPreference?: 'auto',
+  currencyPreference?: CurrencyPreference,
   opts?: RequestOptions
 ): Promise<MintResponse> {
   const body: MintFromUsdcBody = { usdc_amount: usdcAmount, wallet_address: walletAddress };

--- a/types/api.ts
+++ b/types/api.ts
@@ -141,11 +141,12 @@ export interface TransactionsListResponse {
   next_cursor?: string | null;
 }
 
-// Mint
+export type CurrencyPreference = "auto" | "usdc" | "usdc-polygon";
+
 export interface MintFromUsdcBody {
   usdc_amount: string;
   wallet_address: string;
-  currency_preference?: "auto";
+  currency_preference?: CurrencyPreference;
 }
 
 export interface MintResponse {


### PR DESCRIPTION
## Description

Fixes the mint flow so the selected `mintSource` dropdown value is passed to the backend instead of always using `"auto"`.

## Related Issue

Closes #319

## Changes

- added shared `CurrencyPreference` type
- wired selected mint network into `mintFromUsdc`
- improved type safety for mint source state

## Testing

- verified TypeScript compilation with `pnpm tsc --noEmit`
- verified selected network is sent in mint request payload