### PR TITLE
fix(frontend): include blockchain_tx_hash in currency burn flow (#316)

### DIFF
--- a/app/currency/page.tsx
+++ b/app/currency/page.tsx
@@ -25,6 +25,11 @@ import * as mintApi from "@/lib/api/mint";
 import * as burnApi from "@/lib/api/burn";
 import type { MintResponse, BurnResponse } from "@/types/api";
 import { logger } from "@/lib/logger";
+import { useAuth } from "@/contexts/auth-context";
+import { useStellarWalletsKit } from "@/lib/stellar-wallets-kit";
+import { getWalletSecretAnyLocal } from "@/lib/wallet-storage";
+import { Keypair } from "@stellar/stellar-sdk";
+import { submitBurnRedeemSingleClient } from "@/lib/stellar/burning";
 
 /** Local currency units per 1 ACBU from the `/rates` oracle, or null if missing. */
 function localPerAcbu(currency: string, rates: RatesResponse | null): number | null {
@@ -60,6 +65,8 @@ function estimateLocalFromAcbu(
 export default function CurrencyPage() {
   const opts = useApiOpts();
   const { uiError, setApiError, clearError, isSubmitDisabled } = useApiError();
+  const { userId, stellarAddress } = useAuth();
+  const kit = useStellarWalletsKit();
 
   const [activeTab, setActiveTab] = useState<"mint" | "burn" | "international">(
     "mint",
@@ -149,6 +156,64 @@ export default function CurrencyPage() {
         });
       } else if (activeTab === "burn") {
         logger.info("Burning ACBU", { amount: burnAmount, destination: burnDestination }); // <-- ADD LOGGER
+        
+        // Generate blockchain proof before submission
+        if (!userId) throw new Error("Not signed in");
+        if (!stellarAddress) throw new Error("No linked Stellar wallet address.");
+        
+        let burnTxHash: string;
+        const secret = await getWalletSecretAnyLocal(userId, stellarAddress);
+        
+        if (secret) {
+          const localPubKey = Keypair.fromSecret(secret).publicKey();
+          if (stellarAddress && localPubKey !== stellarAddress) {
+            throw new Error(
+              `Local wallet (${localPubKey.slice(0, 6)}…${localPubKey.slice(-4)}) doesn't match the account on record (${stellarAddress.slice(0, 6)}…${stellarAddress.slice(-4)}). Re-import the correct seed from Settings, or update the wallet address, then retry.`,
+            );
+          }
+          const submit = await submitBurnRedeemSingleClient({
+            userAddress: stellarAddress,
+            amountAcbu: burnAmount,
+            currency: "NGN",
+            userSecret: secret,
+          });
+          burnTxHash = submit.transactionHash;
+        } else {
+          if (!kit) {
+            throw new Error(
+              "Your wallet secret isn't available on this device and the wallet connector isn't ready yet. Please wait a moment and retry.",
+            );
+          }
+          const address = await new Promise<string>((resolve, reject) => {
+            kit
+              .openModal({
+                onWalletSelected: async (selectedOption: { id: string }) => {
+                  try {
+                    kit.setWallet(selectedOption.id);
+                    const { address } = await kit.getAddress();
+                    resolve(address);
+                  } catch (err) {
+                    reject(err);
+                  }
+                },
+              })
+              .catch(reject);
+          });
+          if (stellarAddress && address !== stellarAddress) {
+            throw new Error(
+              `Connected wallet (${address.slice(0, 6)}…${address.slice(-4)}) doesn't match the account on record (${stellarAddress.slice(0, 6)}…${stellarAddress.slice(-4)}). Connect the correct wallet (or update your linked wallet), then retry.`,
+            );
+          }
+          const submit = await submitBurnRedeemSingleClient({
+            userAddress: stellarAddress,
+            amountAcbu: burnAmount,
+            currency: "NGN",
+            external: { kit, address },
+          });
+          burnTxHash = submit.transactionHash;
+        }
+        
+        // Submit burn with blockchain proof
         const recipientType =
           burnDestination === "bank"
             ? "bank"
@@ -165,6 +230,7 @@ export default function CurrencyPage() {
             account_name: burnAccountName.trim(),
           },
           opts,
+          burnTxHash,
         );
         setLastTxId(res.transaction_id);
         setLastResponse(res);
@@ -174,6 +240,64 @@ export default function CurrencyPage() {
         });
       } else {
         logger.info("International transfer", { amount: intlAmount, country: intlCountry }); // <-- ADD LOGGER
+        
+        // Generate blockchain proof before submission
+        if (!userId) throw new Error("Not signed in");
+        if (!stellarAddress) throw new Error("No linked Stellar wallet address.");
+        
+        let burnTxHash: string;
+        const secret = await getWalletSecretAnyLocal(userId, stellarAddress);
+        
+        if (secret) {
+          const localPubKey = Keypair.fromSecret(secret).publicKey();
+          if (stellarAddress && localPubKey !== stellarAddress) {
+            throw new Error(
+              `Local wallet (${localPubKey.slice(0, 6)}…${localPubKey.slice(-4)}) doesn't match the account on record (${stellarAddress.slice(0, 6)}…${stellarAddress.slice(-4)}). Re-import the correct seed from Settings, or update the wallet address, then retry.`,
+            );
+          }
+          const submit = await submitBurnRedeemSingleClient({
+            userAddress: stellarAddress,
+            amountAcbu: intlAmount,
+            currency: intlCurrency,
+            userSecret: secret,
+          });
+          burnTxHash = submit.transactionHash;
+        } else {
+          if (!kit) {
+            throw new Error(
+              "Your wallet secret isn't available on this device and the wallet connector isn't ready yet. Please wait a moment and retry.",
+            );
+          }
+          const address = await new Promise<string>((resolve, reject) => {
+            kit
+              .openModal({
+                onWalletSelected: async (selectedOption: { id: string }) => {
+                  try {
+                    kit.setWallet(selectedOption.id);
+                    const { address } = await kit.getAddress();
+                    resolve(address);
+                  } catch (err) {
+                    reject(err);
+                  }
+                },
+              })
+              .catch(reject);
+          });
+          if (stellarAddress && address !== stellarAddress) {
+            throw new Error(
+              `Connected wallet (${address.slice(0, 6)}…${address.slice(-4)}) doesn't match the account on record (${stellarAddress.slice(0, 6)}…${stellarAddress.slice(-4)}). Connect the correct wallet (or update your linked wallet), then retry.`,
+            );
+          }
+          const submit = await submitBurnRedeemSingleClient({
+            userAddress: stellarAddress,
+            amountAcbu: intlAmount,
+            currency: intlCurrency,
+            external: { kit, address },
+          });
+          burnTxHash = submit.transactionHash;
+        }
+        
+        // Submit international transfer with blockchain proof
         const res: BurnResponse = await burnApi.burnAcbu(
           intlAmount,
           intlCurrency,
@@ -183,6 +307,7 @@ export default function CurrencyPage() {
             account_name: intlAccountName.trim(),
           },
           opts,
+          burnTxHash,
         );
         setLastTxId(res.transaction_id);
         setLastResponse(res);


### PR DESCRIPTION
Closes #316 

## Summary 

Implementation Details
1. Added Required Imports
- `[useAuth]` from auth-context
- `[useStellarWalletsKit]` for wallet connections
- `[getWalletSecretAnyLocal]` for local wallet secret retrieval
- `[Keypair]` from Stellar SDK
- `[submitBurnRedeemSingleClient]` from stellar/burning module
2. Updated Component Hooks
Added wallet and auth context hooks to access userId, stellarAddress, and wallet kit.

3. Fixed Burn Flow (NGN Burn Tab)
- Now generates a blockchain transaction hash using `[submitBurnRedeemSingleClient]` before submission
- Handles both local wallet secrets and external wallet connections
- Validates wallet addresses match before proceeding
- Includes the `[blockchainTxHash]` when calling `[burnApi.burnAcbu]`

4. Fixed International Transfer Flow
- Applied the same blockchain proof generation pattern to international transfers
- Ensures all burn operations include on-chain evidence

# Key Features of the Fix
✅ Blockchain Proof Requirement: Every burn submission now includes a valid `[blockchain_tx_hash]`
✅ Wallet Validation: Matches local wallet to on-chain account to prevent signing mismatches
✅ Error Handling: Clear error messages for missing wallets or uninitialized connectors
✅ Reusable Logic: Uses the exact same Stellar transaction generation as the dedicated burn page
✅ No Breaking Changes: Preserves all existing UX behavior for loading, success, and error states
✅ Scope Contained: Changes limited to /currency burns, no unrelated pages touched
✅ No Package Changes: No lockfile modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Stellar blockchain authentication and proof generation for burn and international transfer flows. Users can authenticate using locally stored wallet credentials or by selecting and connecting a wallet through the Stellar wallet kit. Blockchain transaction proofs are now generated and validated as part of the burn redemption process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->