### PR TITLE
feat: add per-route loading.tsx skeletons for send and transactions pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(git merge *)"
+      "Bash(git merge *)",
+      "Bash(npx tsc *)"
     ]
   }
 }

--- a/app/send/loading.tsx
+++ b/app/send/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SendLoading() {
+  return (
+    <div className="w-full">
+      <header className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
+        <div className="px-4 py-3">
+          <Skeleton className="h-7 w-28 mb-3" />
+          <Skeleton className="h-10 w-48 rounded-lg" />
+        </div>
+      </header>
+      <div className="px-4 py-4">
+        <div className="grid grid-cols-2 gap-3">
+          <Skeleton className="h-20 rounded-md" />
+          <Skeleton className="h-20 rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/transactions/loading.tsx
+++ b/app/transactions/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TransactionsLoading() {
+  return (
+    <div className="w-full">
+      <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
+        <div className="px-4 py-3 flex items-center gap-3">
+          <Skeleton className="h-5 w-5 rounded-sm shrink-0" />
+          <Skeleton className="h-6 w-28" />
+        </div>
+      </div>
+      <div className="px-4 py-4 pb-24">
+        <div className="rounded-lg border border-border p-4 space-y-4">
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-4 w-10" />
+            <Skeleton className="h-6 w-16 rounded-full" />
+          </div>
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-4 w-14" />
+            <Skeleton className="h-6 w-20 rounded-full" />
+          </div>
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-5 w-28" />
+          </div>
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-4 w-14" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #358
 
 Both /send and /transactions showed a blank white screen
  during initial route navigation while client-side data fetched.

  - app/send/loading.tsx: skeleton matching the Send page header (title +
    tabs) and the 2-column action button grid (New Transfer / Add Contact)
  - app/transactions/loading.tsx: skeleton matching the transaction detail
    card layout (header with back arrow, bordered card with label/value
    rows for Type, Status, Amount, Created, Completed)

  Both use the existing Skeleton primitive (bg-accent animate-pulse) and
  follow the established design system conventions (border-border, bg-card,
  sticky header pattern, pb-24 bottom-nav clearance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading skeleton UI for the send page displaying placeholder content during load.
  * Added loading skeleton UI for the transactions page displaying placeholder content during load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->