### PR TITLE
fix: resolve mintSource dropdown, i18n hydration, amount overflow, and keystroke validation

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -50,7 +50,7 @@ export default async function RootLayout({
   const messages = await getMessages();
 
   return (
-    <html lang={locale}>
+      <html lang={locale} suppressHydrationWarning>
       <body className={`font-sans antialiased`}>
         <NextIntlClientProvider messages={messages}>
           <ErrorBoundary>

--- a/app/currency/page.tsx
+++ b/app/currency/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { ArrowDown, ArrowUp, TrendingUp } from "lucide-react";
 import { formatAmount } from "@/lib/utils";
+import { useDebounce } from "@/hooks/use-debounce";
 import { useApiOpts } from "@/hooks/use-api";
 import { useApiError } from "@/hooks/use-api-error";
 import { ApiErrorDisplay } from "@/components/ui/api-error-display";
@@ -76,11 +77,13 @@ export default function CurrencyPage() {
 
   // Mint state
   const [mintAmount, setMintAmount] = useState("");
-  const [mintSource, setMintSource] = useState("usdc");
+  const debouncedMintAmount = useDebounce(mintAmount, 300);
+  const [mintSource, setMintSource] = useState("stellar");
   const [mintWalletAddress, setMintWalletAddress] = useState("");
 
   // Burn state
   const [burnAmount, setBurnAmount] = useState("");
+  const debouncedBurnAmount = useDebounce(burnAmount, 300);
   const [burnDestination, setBurnDestination] = useState("bank");
   const [burnAccountNumber, setBurnAccountNumber] = useState("");
   const [burnBankCode, setBurnBankCode] = useState("");
@@ -88,6 +91,7 @@ export default function CurrencyPage() {
 
   // International state
   const [intlAmount, setIntlAmount] = useState("");
+  const debouncedIntlAmount = useDebounce(intlAmount, 300);
   const [intlCurrency, setIntlCurrency] = useState("USD");
   const [intlCountry, setIntlCountry] = useState("US");
   const [intlAccountNumber, setIntlAccountNumber] = useState("");
@@ -117,9 +121,9 @@ export default function CurrencyPage() {
   );
 
   const availableBalance = balance ?? 0;
-  const burnNumeric = parseFloat(burnAmount || "0");
-  const intlNumeric = parseFloat(intlAmount || "0");
-  const mintNumeric = parseFloat(mintAmount || "0");
+  const burnNumeric = parseFloat(debouncedBurnAmount || "0");
+  const intlNumeric = parseFloat(debouncedIntlAmount || "0");
+  const mintNumeric = parseFloat(debouncedMintAmount || "0");
 
   const estimatedMintAcbu = estimateAcbuFromUsd(mintNumeric, rates);
   const estimatedBurnNgn = estimateLocalFromAcbu(burnNumeric, "NGN", rates);
@@ -288,8 +292,7 @@ export default function CurrencyPage() {
                   onChange={(e) => setMintSource(e.target.value)}
                   className="w-full px-3 py-2 border border-border rounded-lg text-sm font-medium bg-background"
                 >
-                  <option value="usdc">USDC (Ethereum)</option>
-                  <option value="usdc-polygon">USDC (Polygon)</option>
+                  <option value="stellar">USDC (Stellar)</option>
                 </select>
               </Card>
 
@@ -309,7 +312,7 @@ export default function CurrencyPage() {
                     className="border-border text-lg font-semibold"
                   />
                 </div>
-                <p className="text-xs text-muted-foreground mt-2">
+                <p className="text-xs text-muted-foreground mt-2 break-words">
                   You'll receive:{" "}
                   {estimatedMintAcbu != null
                     ? `ACBU ${formatAmount(estimatedMintAcbu)}`
@@ -354,8 +357,8 @@ export default function CurrencyPage() {
               <Button
                 onClick={handleMintConfirm}
                 disabled={
-                  !mintAmount ||
-                  parseFloat(mintAmount) <= 0 ||
+                  !debouncedMintAmount ||
+                  parseFloat(debouncedMintAmount) <= 0 ||
                   !mintWalletAddress.trim()
                 }
                 className="w-full bg-primary text-primary-foreground hover:bg-primary/90 mt-6"
@@ -480,7 +483,7 @@ export default function CurrencyPage() {
               <Button
                 onClick={handleBurnConfirm}
                 disabled={
-                  !burnAmount ||
+                  !debouncedBurnAmount ||
                   burnNumeric <= 0 ||
                   (balance != null && burnNumeric > availableBalance) ||
                   !burnAccountNumber.trim() ||
@@ -624,8 +627,8 @@ export default function CurrencyPage() {
                 <Button
                   onClick={() => setStep("confirm")}
                   disabled={
-                    !intlAmount ||
-                    parseFloat(intlAmount) <= 0 ||
+                    !debouncedIntlAmount ||
+                    parseFloat(debouncedIntlAmount) <= 0 ||
                     !intlAccountNumber.trim() ||
                     !intlBankCode.trim() ||
                     !intlAccountName.trim()
@@ -650,7 +653,7 @@ export default function CurrencyPage() {
               {activeTab === "burn" && "Confirm Burn & Withdrawal"}
               {activeTab === "international" && "Confirm Transfer"}
             </AlertDialogTitle>
-            <AlertDialogDescription>
+            <AlertDialogDescription className="break-words">
               {activeTab === 'mint' &&
                 (estimatedMintAcbu != null
                   ? `Mint ACBU ${formatAmount(estimatedMintAcbu)} from USDC`
@@ -664,7 +667,7 @@ export default function CurrencyPage() {
           <div className="py-4 space-y-2">
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Amount:</span>
-              <span className="font-medium text-foreground">
+              <span className="font-medium text-foreground break-words">
                 {activeTab === 'mint' && `$${mintAmount}`}
                 {activeTab === 'burn' && `ACBU ${formatAmount(burnAmount)}`}
                 {activeTab === 'international' && `ACBU ${formatAmount(intlAmount)}`}

--- a/app/mint/page.tsx
+++ b/app/mint/page.tsx
@@ -30,6 +30,7 @@ import * as ratesApi from '@/lib/api/rates';
 import * as fiatApi from '@/lib/api/fiat';
 import type { RatesResponse } from '@/types/api';
 import { formatAmount } from '@/lib/utils';
+import { useDebounce } from '@/hooks/use-debounce';
 import { logger } from '@/lib/logger';
 const MINT_NETWORK_FEE_TEXT = "Estimated at confirmation";
 const BURN_PROCESSING_FEE_TEXT = "Estimated at confirmation";
@@ -71,6 +72,8 @@ export default function MintPage() {
   const [fiatAccounts, setFiatAccounts] = useState<fiatApi.FiatAccount[]>([]);
   const [selectedFiatCurrency, setSelectedFiatCurrency] = useState('');
   const [fiatAmount, setFiatAmount] = useState('');
+  const debouncedFiatAmount = useDebounce(fiatAmount, 300);
+  const debouncedBurnAmount = useDebounce(burnAmount, 300);
   const [mintQuoteRates, setMintQuoteRates] = useState<RatesResponse | null>(null);
   const [mintAcbuReceived, setMintAcbuReceived] = useState<number | null>(null);
   const rateRows = Array.isArray((rates as { rates?: Array<{ currency?: string; rate?: number }> } | null)?.rates)
@@ -78,8 +81,8 @@ export default function MintPage() {
     : [];
 
   const estimatedMintAcbu = useMemo(
-    () => estimateAcbuFromFiat(fiatAmount, selectedFiatCurrency, mintQuoteRates),
-    [fiatAmount, selectedFiatCurrency, mintQuoteRates],
+    () => estimateAcbuFromFiat(debouncedFiatAmount, selectedFiatCurrency, mintQuoteRates),
+    [debouncedFiatAmount, selectedFiatCurrency, mintQuoteRates],
   );
 
   useEffect(() => {
@@ -120,10 +123,14 @@ export default function MintPage() {
     }, [activeTab, opts.token]);
 
     const handleMintConfirm = () => {
+        if (!debouncedFiatAmount || parseFloat(debouncedFiatAmount) <= 0 || !selectedFiatCurrency) return;
         setMintError("");
         setStep("confirm");
     };
-    const handleBurnConfirm = () => setStep("confirm");
+    const handleBurnConfirm = () => {
+        if (!debouncedBurnAmount || parseFloat(debouncedBurnAmount) <= 0 || !selectedFiatCurrency) return;
+        setStep("confirm");
+    };
     const handleExecuteMint = async () => {
         if (!fiatAmount || parseFloat(fiatAmount) <= 0 || !selectedFiatCurrency)
             return;
@@ -444,10 +451,10 @@ export default function MintPage() {
                             </div>
                             {estimatedMintAcbu != null && (
                                 <Card className="border-border bg-muted/80 p-3 mt-3">
-                                    <p className="text-xs text-muted-foreground mb-1">
+                                    <p className="text-xs text-muted-foreground mb-1 break-words">
                                         Estimated ACBU (from latest rates)
                                     </p>
-                                    <p className="text-lg font-semibold text-foreground">
+                                    <p className="text-lg font-semibold text-foreground break-words">
                                         ≈ {formatAmount(estimatedMintAcbu)} ACBU
                                     </p>
                                 </Card>
@@ -465,8 +472,8 @@ export default function MintPage() {
                             <Button
                                 onClick={handleMintConfirm}
                                 disabled={
-                                    !fiatAmount ||
-                                    parseFloat(fiatAmount) <= 0 ||
+                                    !debouncedFiatAmount ||
+                                    parseFloat(debouncedFiatAmount) <= 0 ||
                                     !selectedFiatCurrency
                                 }
                                 className="w-full bg-primary text-primary-foreground hover:bg-primary/90 mt-6"
@@ -604,7 +611,7 @@ export default function MintPage() {
                                 ? "Confirm Mint"
                                 : "Confirm Burn"}
                         </AlertDialogTitle>
-                        <AlertDialogDescription>
+                        <AlertDialogDescription className="break-words">
                             {activeTab === "mint" &&
                                 `Mint ACBU by exchanging ${selectedFiatCurrency} ${formatAmount(fiatAmount)}${
                                     estimatedMintAcbu != null
@@ -620,7 +627,7 @@ export default function MintPage() {
                             <span className="text-muted-foreground">
                                 Amount:
                             </span>
-                            <span className="font-medium text-foreground">
+                            <span className="font-medium text-foreground break-words">
                                 {activeTab === "mint"
                                     ? `${selectedFiatCurrency} ${fiatAmount}`
                                     : `ACBU ${formatAmount(burnAmount)}`}

--- a/app/send/page.tsx
+++ b/app/send/page.tsx
@@ -33,6 +33,7 @@ import * as transfersApi from "@/lib/api/transfers";
 import * as userApi from "@/lib/api/user";
 import type { TransferItem, ContactItem } from "@/types/api";
 import { formatAmount } from "@/lib/utils";
+import { useDebounce } from "@/hooks/use-debounce";
 import { getWalletSecretAnyLocal } from "@/lib/wallet-storage";
 import { useStellarWalletsKit } from "@/lib/stellar-wallets-kit";
 import {
@@ -152,6 +153,7 @@ export default function SendPage() {
       setAmount(v);
     }
   }, []);
+  const debouncedAmount = useDebounce(amount, 300);
   const handleNoteChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setNote(e.target.value), []);
   const handleSendDialogClose = useCallback(() => setShowSendDialog(false), []);
   const handleShowConfirmDialog = useCallback(() => {
@@ -253,14 +255,14 @@ export default function SendPage() {
   }, [confirmedAmount, getToValue, note, userId, stellarAddress, kit, opts, loadTransfers, refreshBalance, clearError]);
 
   const exceedsBalance =
-    balance !== null && amount !== "" && parseFloat(amount) > balance;
+    balance !== null && debouncedAmount !== "" && parseFloat(debouncedAmount) > balance;
 
   const isFormValid = useMemo(() => {
-    return amount &&
-      parseFloat(amount) > 0 &&
+    return debouncedAmount &&
+      parseFloat(debouncedAmount) > 0 &&
       !exceedsBalance &&
       ((useContact && selectedContact) || (!useContact && customRecipient.trim()));
-  }, [amount, exceedsBalance, useContact, selectedContact, customRecipient]);
+  }, [debouncedAmount, exceedsBalance, useContact, selectedContact, customRecipient]);
 
   const transfersList = useMemo(() => {
     if (loadingTransfers) {

--- a/hooks/use-debounce.ts
+++ b/hooks/use-debounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary

Fixes multiple UI/UX issues assigned via Stellar Wave program.

### Changes

**#322 — mintSource dropdown options don't match backend-supported networks**
- Changed dropdown from USDC (Ethereum/Polygon) to USDC (Stellar)
- Updated default mintSource value to `"stellar"`

**#329 — i18n route prefix /[locale] may cause hydration mismatch**
- Added `suppressHydrationWarning` to the `<html>` tag in `app/[locale]/layout.tsx`

**#332 — Form validation runs on every keystroke**
- Created `hooks/use-debounce.ts` hook (300ms delay)
- Applied debounced values to validation logic in `app/send`, `app/mint`, and `app/currency` pages
- Validation errors and preview estimates now update only after the user stops typing

**#334 — Mint amount preview overflows on very large numbers**
- Added `break-words` Tailwind class to formatted amount previews in `app/mint` and `app/currency`
- Applied to confirmation dialog descriptions and amount displays

Closes #322
Closes #329
Closes #332
Closes #334