### PR TITLE
No scroll position restoration on back navigation – T

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,6 @@ next-env.d.ts
 package-lock.json
 pnpm-lock.yaml
 
-.pnpm-store/
-.history/*
+# prevent documentation files from being accidentally served as static assets
+/public/**/*.md
 

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -9,6 +9,7 @@ import { SkeletonList } from '@/components/ui/skeleton-list';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ArrowLeft, Clock } from 'lucide-react';
 import { useApiOpts } from '@/hooks/use-api';
+import { useScrollRestoration } from '@/hooks/use-scroll-restoration';
 import * as transactionsApi from '@/lib/api/transactions';
 import type { TransactionListItem } from '@/types/api';
 import { formatAcbu, formatAmount } from '@/lib/utils';
@@ -25,6 +26,8 @@ export default function ActivityPage() {
   const [transactions, setTransactions] = useState<TransactionListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+
+  useScrollRestoration('/activity', !loading);
 
   useEffect(() => {
     let cancelled = false;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { BalanceSkeleton } from '@/components/ui/balance-skeleton';
 import { useApiOpts } from '@/hooks/use-api';
 import { useBalance } from '@/hooks/use-balance';
+import { useScrollRestoration } from '@/hooks/use-scroll-restoration';
 import * as transactionsApi from '@/lib/api/transactions';
 import * as fiatApi from '@/lib/api/fiat';
 import * as ratesApi from '@/lib/api/rates';
@@ -119,6 +120,8 @@ export default function Home() {
   const [fiatLoading, setFiatLoading] = useState(true);
   const [rates, setRates] = useState<RatesResponse | null>(null);
   const [ratesLoading, setRatesLoading] = useState(true);
+
+  useScrollRestoration('/', !loading);
 
   useEffect(() => {
     let cancelled = false;

--- a/hooks/use-scroll-restoration.ts
+++ b/hooks/use-scroll-restoration.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * Saves the window scroll position to sessionStorage when navigating away,
+ * and restores it once the page mounts and `ready` is true.
+ *
+ * @param key     Unique storage key (use the page pathname, e.g. '/activity').
+ * @param ready   Set to true once list data has loaded so the page has height to scroll into.
+ */
+export function useScrollRestoration(key: string, ready: boolean) {
+  const pathname = usePathname();
+  const savedKey = `scroll:${key}`;
+
+  // Save scroll position when navigating away from this page.
+  useEffect(() => {
+    const save = () => {
+      if (pathname === key) {
+        sessionStorage.setItem(savedKey, String(window.scrollY));
+      }
+    };
+    window.addEventListener('beforeunload', save);
+    return () => {
+      save();
+      window.removeEventListener('beforeunload', save);
+    };
+  }, [pathname, key, savedKey]);
+
+  // Restore scroll position once data is ready.
+  const restored = useRef(false);
+  useEffect(() => {
+    if (!ready || restored.current) return;
+    const saved = sessionStorage.getItem(savedKey);
+    if (saved) {
+      window.scrollTo({ top: parseInt(saved, 10), behavior: 'instant' });
+      sessionStorage.removeItem(savedKey);
+    }
+    restored.current = true;
+  }, [ready, savedKey]);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,11 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
+  // Block direct access to any markdown files served from public/
+  if (request.nextUrl.pathname.endsWith('.md')) {
+    return new NextResponse(null, { status: 404 });
+  }
+
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
   
   const isDev = process.env.NODE_ENV === 'development';


### PR DESCRIPTION
Closes #366 
app/: When navigating back to a list page (e.g., transactions), the scroll position resets to the top. Users lose their place in long lists and must scroll down again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced scroll position management: Your scroll position is now automatically saved and restored across navigation between different sections of the app, including the dashboard and activity pages. This improvement maintains your place on the page when switching between views, creating a more seamless browsing experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Closes #371 