### PR TITLE
fix: exclude static assets from CSP middleware matcher

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -72,10 +72,10 @@ export const config = {
      * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
+     * - favicon.ico and other public static assets (images, fonts, icons)
      */
     {
-      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      source: '/((?!api|_next/static|_next/image|.*\\.(?:ico|png|jpg|jpeg|svg|webp|gif|woff2?|ttf|otf|map)).*)',
       missing: [
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' },


### PR DESCRIPTION
Closes #360

---

## Problem
The middleware `matcher` source pattern excluded `_next/static`, `_next/image`, and `favicon.ico`, but every other public static asset (images, fonts, icons, source maps) still hit the middleware. This caused a nonce to be generated and CSP headers to be set on every JS chunk, image, and font load — unnecessary work that adds latency to each request.

## Fix
Extend the negative lookahead in the `source` pattern to also skip requests whose path ends with a common static file extension:

```
ico, png, jpg, jpeg, svg, webp, gif, woff, woff2, ttf, otf, map
```

## Changes
- `middleware.ts`: Updated `config.matcher[0].source` to exclude static asset extensions

## Before / After
```
# Before
/((?!api|_next/static|_next/image|favicon.ico).*)

# After
/((?!api|_next/static|_next/image|.*\.(?:ico|png|jpg|jpeg|svg|webp|gif|woff2?|ttf|otf|map)).*)
```

## Testing
- Page navigations still receive CSP headers ✅
- Requests to `/logo.png`, `/fonts/inter.woff2`, `/_next/static/chunks/main.js` bypass the middleware ✅
- `.md` block and nonce generation unaffected for page routes ✅