### PR TITLE
fix: standardize toast usage on useToast hook

### DIFF
--- a/app/currency/page.tsx
+++ b/app/currency/page.tsx
@@ -26,6 +26,7 @@ import * as burnApi from "@/lib/api/burn";
 import type { MintResponse, BurnResponse, CurrencyPreference } from "@/types/api";
 import { logger } from "@/lib/logger";
 import { useAuth } from "@/contexts/auth-context";
+import { useToast } from "@/hooks/use-toast";
 import { useStellarWalletsKit } from "@/lib/stellar-wallets-kit";
 import { getWalletSecretAnyLocal } from "@/lib/wallet-storage";
 import { Keypair } from "@stellar/stellar-sdk";
@@ -67,6 +68,7 @@ export default function CurrencyPage() {
   const { uiError, setApiError, clearError, isSubmitDisabled } = useApiError();
   const { userId, stellarAddress } = useAuth();
   const kit = useStellarWalletsKit();
+  const { toast } = useToast();
 
   const [activeTab, setActiveTab] = useState<"mint" | "burn" | "international">(
     "mint",


### PR DESCRIPTION
## Summary

Resolves #367

`app/currency/page.tsx` was calling `toast()` at three call sites without ever importing it, causing a runtime ReferenceError. This fix adds the missing `useToast` import and destructures `toast` from it — matching the pattern already used in `app/send/page.tsx`.

## Changes

- `app/currency/page.tsx`: add `import { useToast } from '@/hooks/use-toast'`
- `app/currency/page.tsx`: add `const { toast } = useToast()` inside the component

## Result

All toast calls now go through the single `useToast` system whose `<Toaster />` is already mounted in the root layout. No duplicate toast containers, consistent styling.