### PR TITLE
fix: add shared in-memory cache to getRates to prevent duplicate fetches

### DIFF
--- a/lib/api/rates.ts
+++ b/lib/api/rates.ts
@@ -2,8 +2,22 @@ import { get } from './client';
 import type { RequestOptions } from './client';
 import type { RatesResponse, QuoteResponse } from '@/types/api';
 
+const RATES_TTL_MS = 60_000; // 1 minute
+
+let cachedRates: RatesResponse | null = null;
+let cacheToken: string | undefined;
+let cacheExpiry = 0;
+
 export async function getRates(opts?: RequestOptions): Promise<RatesResponse> {
-  return get<RatesResponse>('/rates', opts);
+  const now = Date.now();
+  if (cachedRates && opts?.token === cacheToken && now < cacheExpiry) {
+    return cachedRates;
+  }
+  const data = await get<RatesResponse>('/rates', opts);
+  cachedRates = data;
+  cacheToken = opts?.token;
+  cacheExpiry = now + RATES_TTL_MS;
+  return data;
 }
 
 export async function getQuote(


### PR DESCRIPTION
## Summary

Resolves #363

`app/page.tsx` and `app/mint/page.tsx` both call `getRates()` independently on mount. When a user navigates between them the rate data is fetched twice with no shared cache.

## Fix

Added a module-level in-memory cache with a **1-minute TTL** inside `lib/api/rates.ts`. The cache is keyed by auth token so different users never share stale data.

```
getRates() called → cache miss → fetch /rates → store in cache
getRates() called again within 60s, same token → cache hit → return immediately
```

No changes to callers — both pages continue to call `getRates(opts)` exactly as before.

## Why this approach

- Zero new dependencies or context providers
- Transparent to all existing callers
- Cache invalidates automatically on token change (login/logout) and after 1 minute