### PR TITLE
fix: set Content-Type header only when body is present

### DIFF
--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -96,9 +96,10 @@ async function request<T>(
     );
   }
   const url = path.startsWith('http') ? path : `${BASE}${path.startsWith('/') ? path : `/${path}`}`;
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
+  const headers: Record<string, string> = {};
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
   // CSRF cookie logic removed: backend does not guarantee XSRF-TOKEN pairing
 
   const token = opts.token !== undefined ? opts.token : currentToken;


### PR DESCRIPTION
✦ Summary of Changes                                                            
   * Issue: The API client in lib/api/client.ts was unconditionally sending the 
     Content-Type: application/json header in all requests, including GET       
     requests and POST/PUT/PATCH requests without a body. This can lead to      
     server-side issues, such as incorrect MIME type sniffing, or issues with   
     misconfigured CDNs.                                                        
   * Fix: Updated the request function to conditionally set the Content-Type    
     header only when a request body (body !== undefined) is actually present.  
                                                       
closes #310 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API client header handling to send appropriate headers based on request type, ensuring better compatibility with backend services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->