### PR TITLE
chore: optimize package imports & remove unused imports

### DIFF
--- a/app/auth/wallet-setup/page.tsx
+++ b/app/auth/wallet-setup/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+// Dialog components were imported but not used in this page
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";

--- a/app/business/sme/page.tsx
+++ b/app/business/sme/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft, Briefcase, Mail, ArrowRight } from 'lucide-react';
+import { ArrowLeft, Briefcase, Mail } from 'lucide-react';
 
 export default function SmePage() {
   const smeEmail = 'sme@acbu.io';

--- a/app/fiat/page.tsx
+++ b/app/fiat/page.tsx
@@ -17,10 +17,9 @@ export default function FiatSimPage() {
   const opts = useApiOpts();
   const { userId, stellarAddress } = useAuth();
   const kit = useStellarWalletsKit();
-  const { uiError, setApiError, clearError, isSubmitDisabled } = useApiError();
+  const { uiError, setApiError, clearError, isSubmitDisabled, handleError } = useApiError();
   const [accounts, setAccounts] = useState<fiatApi.FiatAccount[]>([]);
   const [loading, setLoading] = useState(true);
-  const { error, clearError, handleError } = useApiError();
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [lastFaucetTx, setLastFaucetTx] = useState<string | null>(null);
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,19 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // Improve tree-shaking for large packages and local UI exports
+  experimental: {
+    optimizePackageImports: {
+      'lucide-react': {
+        transform: 'lucide-react/dist/esm/icons/{{member}}',
+        preventFullImport: true,
+      },
+      '@/components/ui': {
+        transform: '@/components/ui/{{member}}',
+        preventFullImport: true,
+      },
+    },
+  },
   // Don't advertise the framework to reduce attack surface
   poweredByHeader: false,
   async redirects() {

--- a/scripts/find-unused-imports.cjs
+++ b/scripts/find-unused-imports.cjs
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+
+function readFiles(dir) {
+  const list = [];
+  const items = fs.readdirSync(dir, { withFileTypes: true });
+  for (const it of items) {
+    const full = path.join(dir, it.name);
+    if (it.isDirectory()) list.push(...readFiles(full));
+    else if (/\.tsx?$/.test(it.name)) list.push(full);
+  }
+  return list;
+}
+
+function parseImports(content) {
+  const imports = [];
+  const re = /import\s+([^;]+)\s+from\s+['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(content))) {
+    imports.push({ spec: m[1].trim(), source: m[2] });
+  }
+  return imports;
+}
+
+function extractNamed(spec) {
+  const res = [];
+  if (spec.startsWith('{')) {
+    const inside = spec.replace(/^{|}$/g, '').trim();
+    inside.split(',').map(s => s.trim()).forEach(s => {
+      const parts = s.split(/\s+as\s+/);
+      res.push(parts[0].trim());
+    });
+  } else if (spec.includes('{')) {
+    const parts = spec.split(',');
+    const after = parts.slice(1).join(',').trim();
+    if (after.startsWith('{')) {
+      const inside = after.replace(/^{|}$/g, '').trim();
+      inside.split(',').map(s => s.trim()).forEach(s => {
+        const p = s.split(/\s+as\s+/);
+        res.push(p[0].trim());
+      });
+    }
+  }
+  return res;
+}
+
+function findUnusedInFile(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const imports = parseImports(content);
+  const unused = [];
+  for (const imp of imports) {
+    if (imp.source === 'lucide-react' || imp.source === "lucide-react") {
+      const named = extractNamed(imp.spec);
+      for (const n of named) {
+        const re = new RegExp("\\b" + n + "\\b", 'g');
+        const count = (content.match(re) || []).length;
+        if (count <= 1) unused.push({ type: 'icon', name: n });
+      }
+    }
+    if (imp.source.startsWith('@/components/ui') || imp.source === "@/components/ui") {
+      const named = extractNamed(imp.spec);
+      for (const n of named) {
+        const re = new RegExp("\\b" + n + "\\b", 'g');
+        const count = (content.match(re) || []).length;
+        if (count <= 1) unused.push({ type: 'ui', name: n });
+      }
+    }
+    if (imp.source === 'react' || imp.source === "react") {
+      const hooks = ['useState','useEffect','useMemo','useCallback','useRef','useContext'];
+      const named = extractNamed(imp.spec);
+      for (const n of named) {
+        if (hooks.includes(n)) {
+          const re = new RegExp("\\b" + n + "\\b", 'g');
+          const count = (content.match(re) || []).length;
+          if (count <= 1) unused.push({ type: 'hook', name: n });
+        }
+      }
+    }
+  }
+  return unused.length ? { file, unused } : null;
+}
+
+const files = readFiles(path.join(process.cwd(), 'app'));
+const report = [];
+for (const f of files) {
+  const r = findUnusedInFile(f);
+  if (r) report.push(r);
+}
+console.log(JSON.stringify(report, null, 2));

--- a/scripts/find-unused-imports.js
+++ b/scripts/find-unused-imports.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const path = require('path');
+
+function readFiles(dir) {
+  const list = [];
+  const items = fs.readdirSync(dir, { withFileTypes: true });
+  for (const it of items) {
+    const full = path.join(dir, it.name);
+    if (it.isDirectory()) list.push(...readFiles(full));
+    else if (/\.tsx?$/.test(it.name)) list.push(full);
+  }
+  return list;
+}
+
+function parseImports(content) {
+  const imports = [];
+  const re = /import\s+([^;]+)\s+from\s+['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(content))) {
+    imports.push({ spec: m[1].trim(), source: m[2] });
+  }
+  return imports;
+}
+
+function extractNamed(spec) {
+  // handles: { A, B as C } or React, { useState }
+  const res = [];
+  if (spec.startsWith('{')) {
+    const inside = spec.replace(/^{|}$/g, '').trim();
+    inside.split(',').map(s => s.trim()).forEach(s => {
+      const parts = s.split(/\s+as\s+/);
+      res.push(parts[0].trim());
+    });
+  } else if (spec.includes('{')) {
+    // e.g. React, { useState }
+    const parts = spec.split(',');
+    const after = parts.slice(1).join(',').trim();
+    if (after.startsWith('{')) {
+      const inside = after.replace(/^{|}$/g, '').trim();
+      inside.split(',').map(s => s.trim()).forEach(s => {
+        const p = s.split(/\s+as\s+/);
+        res.push(p[0].trim());
+      });
+    }
+  }
+  return res;
+}
+
+function findUnusedInFile(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const imports = parseImports(content);
+  const unused = [];
+  for (const imp of imports) {
+    if (imp.source === 'lucide-react' || imp.source === "lucide-react") {
+      const named = extractNamed(imp.spec);
+      for (const n of named) {
+        const re = new RegExp("\\b" + n + "\\b", 'g');
+        const count = (content.match(re) || []).length;
+        // if only appears in import statement (count === 1), it's unused
+        if (count <= 1) unused.push({ type: 'icon', name: n });
+      }
+    }
+    // local ui imports
+    if (imp.source.startsWith('@/components/ui') || imp.source === "@/components/ui") {
+      // extract members from spec
+      const named = extractNamed(imp.spec);
+      for (const n of named) {
+        const re = new RegExp("\\b" + n + "\\b", 'g');
+        const count = (content.match(re) || []).length;
+        if (count <= 1) unused.push({ type: 'ui', name: n });
+      }
+    }
+    // react hooks
+    if (imp.source === 'react' || imp.source === "react") {
+      const hooks = ['useState','useEffect','useMemo','useCallback','useRef','useContext'];
+      const named = extractNamed(imp.spec);
+      for (const n of named) {
+        if (hooks.includes(n)) {
+          const re = new RegExp("\\b" + n + "\\b", 'g');
+          const count = (content.match(re) || []).length;
+          if (count <= 1) unused.push({ type: 'hook', name: n });
+        }
+      }
+    }
+  }
+  return unused.length ? { file, unused } : null;
+}
+
+const files = readFiles(path.join(process.cwd(), 'app'));
+const report = [];
+for (const f of files) {
+  const r = findUnusedInFile(f);
+  if (r) report.push(r);
+}
+console.log(JSON.stringify(report, null, 2));


### PR DESCRIPTION
# chore: optimize imports & remove unused imports

Summary
- Add Next.js package-import optimization to improve tree-shaking for `lucide-react` and local UI exports.
- Remove several unused imports in page components to reduce bundle size and silence ESLint warnings.
- Add a small detection script `scripts/find-unused-imports.cjs` to help find remaining unused icons/hooks.

Files changed
- `next.config.mjs` — added `experimental.optimizePackageImports` entries
- `app/auth/wallet-setup/page.tsx` — removed unused `Dialog*` imports
- `app/business/sme/page.tsx` — removed unused `ArrowRight` icon import
- `scripts/find-unused-imports.cjs`, `scripts/find-unused-imports.js` — added detection scripts

Testing & Notes
- I created branch `fix/optimize-imports-unused-imports` and pushed the changes.
- I could not run `pnpm lint -- --fix` or the test suite in this environment (pnpm not available). Please run the lint and tests locally or in CI and apply/approve any additional fixes.

Recommended local steps
```bash
git checkout fix/optimize-imports-unused-imports
pnpm install
pnpm lint -- --fix
pnpm test
git add -A
git commit -m "chore: fix lint issues"
git push
```

Checklist
- [x] Add `experimental.optimizePackageImports` to `next.config.mjs`
- [x] Remove obvious unused imports detected
- [x] Add detection script for unused imports
- [ ] Run `pnpm lint -- --fix` and apply remaining fixes
- [ ] Confirm tests pass and open PR



close #353   close #349