### PR TITLE
fix: consistent loading skeletons on send, mint, burn pages (#324)

### DIFF
--- a/app/burn/page.tsx
+++ b/app/burn/page.tsx
@@ -7,9 +7,11 @@ import { PageContainer } from "@/components/layout/page-container";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ArrowLeft } from "lucide-react";
-import { useSearchParams } from "next/navigation";
-import { useApiOpts, useApiError } from "@/hooks/use-api";
+import { ArrowLeft, CheckCircle } from "lucide-react";
+import { useApiOpts } from "@/hooks/use-api";
+import { useApiError } from "@/hooks/use-api-error";
+import { ApiErrorDisplay } from "@/components/ui/api-error-display";
+import { SkeletonList } from "@/components/ui/skeleton-list";
 import * as burnApi from "@/lib/api/burn";
 import type { BurnRecipientAccount } from "@/types/api";
 import { useAuth } from "@/contexts/auth-context";
@@ -29,7 +31,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { cn } from "@/lib/utils";
 
 const burnSchema = z.object({
   acbuAmount: z.string().refine((val: string) => !isNaN(parseFloat(val)) && parseFloat(val) > 0, {
@@ -56,7 +57,6 @@ const formatCurrency = (amount: string, currency: string) => {
   if (isNaN(value)) return "";
 
   try {
-    // Use current browser locale for proper grouping separators
     return new Intl.NumberFormat(navigator.language || 'en-US', {
       style: "currency",
       currency,
@@ -71,23 +71,15 @@ function BurnPageContent() {
   const searchParams = useSearchParams();
   const { userId, stellarAddress } = useAuth();
   const kit = useStellarWalletsKit();
-  
-  // Initialize from search params if available
-  const [acbuAmount, setAcbuAmount] = useState(searchParams.get("amount") || "");
-  const [currency, setCurrency] = useState(searchParams.get("currency") || "NGN");
-  
-  const [accountNumber, setAccountNumber] = useState("");
-  const [bankCode, setBankCode] = useState("");
-  const [accountName, setAccountName] = useState("");
-  const { error, clearError, handleError } = useApiError();
+  const { uiError, setApiError, clearError, isSubmitDisabled } = useApiError();
   const [loading, setLoading] = useState(false);
   const [txId, setTxId] = useState<string | null>(null);
 
   const form = useForm<BurnFormValues>({
     resolver: zodResolver(burnSchema),
     defaultValues: {
-      acbuAmount: "",
-      currency: "NGN",
+      acbuAmount: searchParams.get("amount") || "",
+      currency: searchParams.get("currency") || "NGN",
       accountNumber: "",
       bankCode: "",
       accountName: "",
@@ -95,28 +87,15 @@ function BurnPageContent() {
     mode: "onChange",
   });
 
-  const isValid =
-    acbuAmount &&
-    parseFloat(acbuAmount) > 0 &&
-    currency.length === 3 &&
-    accountNumber.trim().length >= 5 &&
-    accountNumber.trim().length <= 20 &&
-    bankCode.trim().length >= 3 &&
-    bankCode.trim().length <= 10 &&
-    accountName.trim().length >= 3 &&
-    accountName.trim().length <= 100;
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!isValid) return;
+  const onSubmit = async (values: BurnFormValues) => {
     clearError();
     setLoading(true);
     setTxId(null);
-    
+
     try {
       if (!userId) throw new Error("Not signed in");
       if (!stellarAddress) throw new Error("No linked Stellar wallet address.");
-      
+
       const recipientAccount: BurnRecipientAccount = {
         account_number: values.accountNumber.trim(),
         bank_code: values.bankCode.trim(),
@@ -126,7 +105,7 @@ function BurnPageContent() {
 
       const secret = await getWalletSecretAnyLocal(userId, stellarAddress);
       let burnTxHash: string;
-      
+
       if (secret) {
         const localPubKey = Keypair.fromSecret(secret).publicKey();
         if (stellarAddress && localPubKey !== stellarAddress) {
@@ -184,13 +163,15 @@ function BurnPageContent() {
         burnTxHash,
       );
       setTxId(res.transaction_id);
-      form.reset({ ...values, acbuAmount: "" }); // Reset amount but keep details for convenience? Or full reset?
+      form.reset({ ...values, acbuAmount: "" });
     } catch (e) {
-      handleError(e);
+      setApiError(e);
     } finally {
       setLoading(false);
     }
   };
+
+  const currency = form.watch("currency");
 
   return (
     <>
@@ -198,7 +179,7 @@ function BurnPageContent() {
         <div className="page-header-row">
           <Link
             href="/mint"
-            aria-label="Go back to Mint page" 
+            aria-label="Go back to Mint page"
             className="touch-target"
           >
             <ArrowLeft className="w-5 h-5 text-primary" />
@@ -215,12 +196,6 @@ function BurnPageContent() {
             <ApiErrorDisplay error={uiError} onDismiss={clearError} />
           )}
           {txId && (
-            <p className="text-green-600 text-sm">
-              Transaction submitted: {txId}
-            </p>
-          )}
-          
-          {txId && (
             <div className="bg-green-500/10 border border-green-500/20 rounded-lg p-3 flex items-start gap-2">
               <CheckCircle className="w-4 h-4 text-green-600 shrink-0 mt-0.5" />
               <p className="text-green-600 text-sm font-medium">
@@ -230,7 +205,7 @@ function BurnPageContent() {
           )}
 
           <Form {...form}>
-            <form onSubmit={formHandleSubmit(onSubmit)} className="space-y-4">
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField
                 control={form.control}
                 name="acbuAmount"
@@ -360,15 +335,34 @@ function BurnPageContent() {
                   </FormItem>
                 )}
               />
-            </div>
-            <Button
-              type="submit"
-              disabled={!isValid || loading || isSubmitDisabled}
-              className="w-full"
-            >
-              {loading ? "Submitting..." : "Burn & Withdraw"}
-            </Button>
-          </form>
+
+              <Button
+                type="submit"
+                disabled={!form.formState.isValid || loading || isSubmitDisabled}
+                className="w-full"
+              >
+                {loading ? "Submitting..." : "Burn & Withdraw"}
+              </Button>
+            </form>
+          </Form>
+        </Card>
+      </PageContainer>
+    </>
+  );
+}
+
+function BurnPageSkeleton() {
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-header-row">
+          <div className="w-9 h-9" />
+          <div className="h-6 w-40 bg-accent animate-pulse rounded-md" />
+        </div>
+      </div>
+      <PageContainer>
+        <Card className="border-border p-4 space-y-4">
+          <SkeletonList count={5} itemHeight="h-14" />
         </Card>
       </PageContainer>
     </>
@@ -377,7 +371,7 @@ function BurnPageContent() {
 
 export default function BurnPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<BurnPageSkeleton />}>
       <BurnPageContent />
     </Suspense>
   );

--- a/app/mint/page.tsx
+++ b/app/mint/page.tsx
@@ -16,7 +16,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { Skeleton } from '@/components/ui/skeleton';
+import { SkeletonList } from '@/components/ui/skeleton-list';
+import { BalanceSkeleton } from '@/components/ui/balance-skeleton';
 import { ArrowDown, ArrowUp, ArrowLeft } from 'lucide-react';
 import { useApiOpts } from '@/hooks/use-api';
 import { useApiError } from '@/hooks/use-api-error';
@@ -35,6 +36,11 @@ import type { RatesResponse } from '@/types/api';
 import { formatAmount } from '@/lib/utils';
 import { logger } from '@/lib/logger';
 import { useI18n } from '@/contexts/i18n-context';
+
+function formatRate(rate: number | undefined): string {
+  if (rate == null || !Number.isFinite(rate)) return '—';
+  return rate.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
 
 /** `acbu_*` from API = local currency units per 1 ACBU → ACBU = fiat / localPerAcbu. */
 function estimateAcbuFromFiat(
@@ -73,6 +79,7 @@ export default function MintPage() {
   const [txId, setTxId] = useState<string | null>(null);
   const [executing, setExecuting] = useState(false);
   const [fiatAccounts, setFiatAccounts] = useState<fiatApi.FiatAccount[]>([]);
+  const [fiatAccountsLoading, setFiatAccountsLoading] = useState(true);
   const [selectedFiatCurrency, setSelectedFiatCurrency] = useState('');
   const [fiatAmount, setFiatAmount] = useState('');
   const [mintQuoteRates, setMintQuoteRates] = useState<RatesResponse | null>(null);
@@ -110,7 +117,8 @@ export default function MintPage() {
           setSelectedFiatCurrency(res.accounts[0].currency);
         }
       })
-      .catch((e) => logger.error('Failed to get fiat accounts', e));
+      .catch((e) => logger.error('Failed to get fiat accounts', e))
+      .finally(() => setFiatAccountsLoading(false));
   }, [opts.token]);
 
     useEffect(() => {
@@ -349,9 +357,13 @@ export default function MintPage() {
                         <p className="text-sm font-medium opacity-90">
                             {t('mint.acbuBalance')}
                         </p>
-                        <p className="text-3xl font-bold mb-2">
-                            {balanceLoading ? '...' : `ACBU ${formatAmount(balance)}`}
-                        </p>
+                        {balanceLoading ? (
+                            <BalanceSkeleton variant="compact" className="mb-2 opacity-60" />
+                        ) : (
+                            <p className="text-3xl font-bold mb-2">
+                                ACBU {formatAmount(balance)}
+                            </p>
+                        )}
                         <p className="text-xs opacity-75">
                             {balanceSource === "stellar"
                                 ? t('mint.balanceFromHorizon')
@@ -403,6 +415,9 @@ export default function MintPage() {
                                 >
                                     {t('mint.basketCurrency')}
                                 </label>
+                                {fiatAccountsLoading ? (
+                                    <SkeletonList count={1} itemHeight="h-10" />
+                                ) : (
                                 <select
                                     id="fiat-account"
                                     value={selectedFiatCurrency}
@@ -410,7 +425,7 @@ export default function MintPage() {
                                     className="w-full px-3 py-2 border border-border rounded-lg text-sm font-medium bg-background"
                                 >
                                     {fiatAccounts.length === 0 ? (
-                                        <option value="" disabled>Loading currencies…</option>
+                                        <option value="" disabled>No currencies available</option>
                                     ) : (
                                         fiatAccounts.map(acc => (
                                             <option key={acc.id} value={acc.currency}>
@@ -419,6 +434,7 @@ export default function MintPage() {
                                         ))
                                     )}
                                 </select>
+                                )}
                             </div>
                             <div className="mt-4">
                                 <label
@@ -495,6 +511,9 @@ export default function MintPage() {
                                 >
                                     {t('mint.basketCurrency')}
                                 </label>
+                                {fiatAccountsLoading ? (
+                                    <SkeletonList count={1} itemHeight="h-10" />
+                                ) : (
                                 <select
                                     id="burn-fiat-account"
                                     value={selectedFiatCurrency}
@@ -502,7 +521,7 @@ export default function MintPage() {
                                     className="w-full px-3 py-2 border border-border rounded-lg text-sm font-medium bg-background"
                                 >
                                     {fiatAccounts.length === 0 ? (
-                                        <option value="" disabled>Loading currencies…</option>
+                                        <option value="" disabled>No currencies available</option>
                                     ) : (
                                         fiatAccounts.map(acc => (
                                             <option key={acc.id} value={acc.currency}>
@@ -511,6 +530,7 @@ export default function MintPage() {
                                         ))
                                     )}
                                 </select>
+                                )}
                             </div>
                             <div className="mt-4">
                                 <label
@@ -536,7 +556,7 @@ export default function MintPage() {
                                 </div>
                                 <p className="text-xs text-muted-foreground mt-2">
                                     {t('mint.available')}: ACBU{" "}
-                                    {balanceLoading ? '...' : formatAmount(balance)}
+                                    {balanceLoading ? <span className="inline-block h-3 w-16 bg-accent animate-pulse rounded align-middle" /> : formatAmount(balance)}
                                 </p>
                             </div>
                             <Card className="border-border bg-muted p-3 mt-4">
@@ -577,7 +597,7 @@ export default function MintPage() {
           <TabsContent value="rates" className="py-6 space-y-4">
             <div className="space-y-3">
               {ratesLoading ? (
-                <Skeleton className="h-20 w-full" />
+                <SkeletonList count={3} itemHeight="h-16" />
               ) : rateRows.length ? (
                 rateRows.map((r) => (
                   <Card key={r.currency} className="border-border p-4">

--- a/app/send/page.tsx
+++ b/app/send/page.tsx
@@ -26,11 +26,12 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsTrigger, TabsList } from "@/components/ui/tabs";
 import { SkeletonList } from "@/components/ui/skeleton-list";
+import { ApiErrorDisplay } from "@/components/ui/api-error-display";
 import { Plus, Check, AlertCircle, ArrowRight } from "lucide-react";
 import { useApiOpts } from "@/hooks/use-api";
 import { useApiError } from "@/hooks/use-api-error";
+import { useToast } from "@/hooks/use-toast";
 import { useI18n } from "@/contexts/i18n-context";
-import { mapApiError } from "@/lib/api/client";
 import { useBalance } from "@/hooks/use-balance";
 import { useAuth } from "@/contexts/auth-context";
 import * as transfersApi from "@/lib/api/transfers";
@@ -161,7 +162,7 @@ export default function SendPage() {
   const handleConfirmTransfer = useCallback(async () => {
     const to = getToValue();
     if (!amount || parseFloat(amount) <= 0 || !to) return;
-    clearSubmitError();
+    clearError();
     setSending(true);
     
     try {
@@ -244,7 +245,7 @@ export default function SendPage() {
       }, 2500);
       
     } catch (e) {
-      handleSubmitError(e);
+      setApiError(e);
     } finally {
       setSending(false);
     }
@@ -389,6 +390,9 @@ export default function SendPage() {
                   <TabsTrigger value="custom">{t('send.newAddress')}</TabsTrigger>
                 </TabsList>
                 <TabsContent value="contact" className="mt-3">
+                  {loadingContacts ? (
+                    <SkeletonList count={3} itemHeight="h-9" />
+                  ) : (
                   <Select
                     value={selectedContact?.id || ""}
                     onValueChange={(id: string) => {
@@ -431,6 +435,7 @@ export default function SendPage() {
                       </div>
                     </SelectContent>
                   </Select>
+                  )}
                 </TabsContent>
                 <TabsContent value="custom" className="mt-3">
                   <Input
@@ -466,7 +471,7 @@ export default function SendPage() {
               </div>
               {exceedsBalance && <p className="text-xs text-destructive">{t('send.insufficientBalance')}</p>}
               <p className="text-xs text-muted-foreground">
-                {t('send.available')}: ACBU {balanceLoading ? "..." : formatAmount(balance)}
+                {t('send.available')}: ACBU {balanceLoading ? <span className="inline-block h-3 w-16 bg-accent animate-pulse rounded align-middle" /> : formatAmount(balance)}
               </p>
             </div>
 
@@ -501,7 +506,7 @@ export default function SendPage() {
                   setConfirmedAmount(amount);
                   setShowConfirmDialog(true);
                 }}
-                disabled={!isFormValid()}
+                disabled={!isValid}
                 className="flex-1 bg-primary text-primary-foreground hover:bg-primary/90"
               >
                 {t('send.continue')}


### PR DESCRIPTION
## Summary

Fixes #324 — loading UX was inconsistent across `/send`, `/mint`, and `/burn`.

## Changes

**`app/burn/page.tsx`**
- Replaced bare `<div>Loading...</div>` Suspense fallback with `BurnPageSkeleton` (SkeletonList)
- Fixed broken variable refs (`values.*`, `formHandleSubmit`, `uiError`, `isSubmitDisabled`, `CheckCircle`, `ApiErrorDisplay`); wired react-hook-form correctly
- Removed duplicate `useSearchParams` import

**`app/mint/page.tsx`**
- Added `fiatAccountsLoading` state; replaced `Loading currencies…` option with `SkeletonList` in mint and burn tabs
- Replaced `balanceLoading ? '...'` with animated inline skeleton spans
- Replaced single `<Skeleton>` in rates tab with `<SkeletonList count={3}>`
- Added missing `formatRate` helper

**`app/send/page.tsx`**
- Added missing `useToast` and `ApiErrorDisplay` imports
- Fixed `clearSubmitError` → `clearError`, `handleSubmitError` → `setApiError`, `isFormValid()` → `isValid`
- Show `SkeletonList` while contacts load in the send dialog
- Replaced `balanceLoading ? "..."` with inline skeleton span

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced form validation and error handling across burn, mint, and send pages.
  * Improved loading state placeholders with animated skeleton loaders.

* **Bug Fixes**
  * Better error display and management in transaction workflows.
  * Fixed form submission handling and validation logic.

* **Style**
  * Updated transaction success display with new success banner styling.
  * Refined loading placeholders for currencies, balances, and contacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->