### PR TITLE
fix: WCAG 2.5.5 minimum 44px touch targets

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -21,12 +21,12 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'size-9',
-        'icon-sm': 'size-8',
-        'icon-lg': 'size-10',
+        default: 'h-11 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-9 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-12 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-11',
+        'icon-sm': 'size-9',
+        'icon-lg': 'size-12',
       },
     },
     defaultVariants: {

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-2 right-2 flex size-11 items-center justify-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -72,7 +72,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-2 right-2 flex size-11 items-center justify-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>


### PR DESCRIPTION
Closes #346

---

## Summary
Fixes WCAG 2.5.5 (Target Size) violations where interactive elements were smaller than the 44×44 CSS pixel minimum required for accurate touch input on mobile.

## Changes

**`components/ui/button.tsx`**
- `default`: `h-9` → `h-11` (36px → 44px)
- `sm`: `h-8` → `h-9` (32px → 36px — closest practical size; still improved)
- `lg`: `h-10` → `h-12` (40px → 48px)
- `icon`: `size-9` → `size-11` (36px → 44px)
- `icon-sm`: `size-8` → `size-9` (32px → 36px)
- `icon-lg`: `size-10` → `size-12` (40px → 48px)

**`components/ui/dialog.tsx`**
- Close button: added `size-11 flex items-center justify-center`, adjusted position to `top-2 right-2`

**`components/ui/sheet.tsx`**
- Close button: added `size-11 flex items-center justify-center`, adjusted position to `top-2 right-2`

## Testing
- Build verified: 20 pre-existing errors on base branch, no new errors introduced by these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Adjusted button size variant dimensions across default, small, and large sizes with updated icon sizing
* Repositioned close buttons in dialog and sheet components for improved visual consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->