### PR TITLE
fix: ensure mobile nav keyboard order matches visual order (tabIndex)

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -58,14 +58,19 @@ export function MobileNav() {
       style={{ bottom: `${bottomOffset}px` }}
     >
       <div className="flex justify-between items-center h-20 px-1">
-        {navItems.map((item) => {
+        {navItems.map((item, idx) => {
           const isActive = pathname === item.href;
           const showLabels = true;
+          // Explicitly set tabIndex to match the visual left-to-right order.
+          // Using positive tabindex values here ensures keyboard focus
+          // follows the same sequence users see on screen.
+          const tabIndex = idx + 1;
           return (
             <Link
               key={item.href}
               href={item.href}
               aria-label={item.name}
+              tabIndex={tabIndex}
               className={`flex flex-col items-center justify-center flex-1 h-20 gap-1 transition-colors ${
                 isActive
                   ? "text-primary"


### PR DESCRIPTION
Summary

Fixes keyboard focus order for the bottom mobile navigation so it matches the visual left-to-right order. 



Closes #355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation focus order in the mobile menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-frontend/pull/428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->