### PR TITLE
fix: prevent rapid double-tap from pushing duplicate history entries

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import React, { useRef, useState, useEffect, useTransition } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { Home, Send, Coins, Briefcase, User, Wallet } from "lucide-react";
 
 interface NavItem {
@@ -26,7 +25,14 @@ const navItems: NavItem[] = [
 
 export function MobileNav() {
   const pathname = usePathname();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const navigatingTo = useRef<string | null>(null);
   const [bottomOffset, setBottomOffset] = useState(0);
+
+  useEffect(() => {
+    navigatingTo.current = null;
+  }, [pathname]);
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.visualViewport) return;
@@ -50,6 +56,14 @@ export function MobileNav() {
     };
   }, []);
 
+  function handleNav(href: string) {
+    if (isPending || navigatingTo.current !== null || pathname === href) return;
+    navigatingTo.current = href;
+    startTransition(() => {
+      router.push(href);
+    });
+  }
+
   return (
     <nav
       className="fixed bottom-0 left-0 right-0 border-t border-border bg-card z-40 transition-[bottom] duration-150 ease-out md:h-auto"
@@ -66,10 +80,11 @@ export function MobileNav() {
           // follows the same sequence users see on screen.
           const tabIndex = idx + 1;
           return (
-            <Link
+            <button
               key={item.href}
-              href={item.href}
+              onClick={() => handleNav(item.href)}
               aria-label={item.name}
+              disabled={isPending}
               tabIndex={tabIndex}
               className={`flex flex-col items-center justify-center flex-1 h-20 gap-1 transition-colors ${
                 isActive
@@ -88,7 +103,7 @@ export function MobileNav() {
               ) : (
                 <span className="sr-only">{item.name}</span>
               )}
-            </Link>
+            </button>
           );
         })}
       </div>


### PR DESCRIPTION
Closes #328 

## Problem

Rapidly tapping two nav tabs in succession can push two routes onto the history stack before the first one completes, corrupting the back-button history on mobile.

## Root Cause

The previous `useTransition` guard was insufficient — `isPending` is an async React state update. A second tap could arrive before React re-renders with `isPending=true`, and there was no synchronous lock preventing the second `router.push` from executing.

## Fix (`components/mobile-nav.tsx`)

- Replaced `<Link>` with `<button>` + `handleNav()` handler for full navigation control
- Synchronous ref-based lock (`navigatingTo`) is set on click and only cleared when `pathname` actually changes (via `useEffect`), preventing any second navigation while one is in-flight
- `useTransition` provides the `isPending` flag to visually disable buttons during navigation
- `pathname === href` guard skips re-pushing the current page
- Preserves existing features: visualViewport keyboard handling, tabIndex ordering, icon wrapping

Closes #328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Mobile navigation now prevents accidental duplicate navigation attempts while transitions are in progress, enhancing overall navigation reliability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->