### PR TITLE
 Fix theme-color meta tag to use brand color on Android Chrome

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,7 +72,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   userScalable: true,
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: light)', color: '#433875' },
     { media: '(prefers-color-scheme: dark)', color: '#1a0a2e' },
   ],
 }


### PR DESCRIPTION
The themeColor viewport export in app/layout.tsx defined #ffffff for light mode, causing the Android Chrome address bar to display white instead of the app's brand color. Updated the light-mode value to #433875 (the app's primary brand purple), matching the app's design system. The dark-mode value (#1a0a2e) was already correct and unchanged.

Closes #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the browser/device theme color for light mode to a purple shade, enhancing visual consistency with the application's design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->