### PR TITLE
Fix/api gzip compression

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -89,6 +89,7 @@ export default async function RootLayout({
   return (
     <html lang={lang} dir="ltr" suppressHydrationWarning>
       <head>
+        <link rel="preload" href="/placeholder-logo.svg" as="image" type="image/svg+xml" />
         {/*
           Print stylesheet is deferred until the browser enters print mode.
           media="print" prevents the browser from downloading and parsing

--- a/app/me/settings/security/page.tsx
+++ b/app/me/settings/security/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
 };
 
 import React, { useMemo, useState } from 'react';
+import { plural } from '@/lib/plural';
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';
@@ -119,7 +120,7 @@ export default function SecurityPage() {
                 <p className="text-sm text-muted-foreground">Review signed-in sessions and revoke any compromised access.</p>
               </div>
               <span className="rounded-full bg-secondary/15 px-3 py-1 text-xs font-medium text-secondary-foreground">
-                {activeSessionCount} active
+                {plural(activeSessionCount, { one: '# active', other: '# active' })}
               </span>
             </div>
             <div className="space-y-3">

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useDeferredValue } from 'react';
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';
@@ -23,6 +23,15 @@ export default function TransactionsPage() {
   const [items, setItems] = useState<TransactionListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query);
+  const filtered = deferredQuery
+    ? items.filter((t) =>
+        t.type.includes(deferredQuery.toLowerCase()) ||
+        t.status.includes(deferredQuery.toLowerCase()) ||
+        t.transaction_id.toLowerCase().includes(deferredQuery.toLowerCase())
+      )
+    : items;
 
   useScrollRestoration('/transactions', !loading);
 
@@ -50,17 +59,26 @@ export default function TransactionsPage() {
       </div>
       <PageContainer>
         {error && <p className="text-destructive text-sm mb-3">{error}</p>}
+        {!loading && items.length > 0 && (
+          <input
+            type="search"
+            placeholder="Filter by type, status, or ID…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full mb-3 px-3 py-2 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+        )}
         {loading ? (
           <SkeletonList count={5} />
-        ) : items.length === 0 ? (
+        ) : filtered.length === 0 ? (
           <EmptyState
             icon={<Clock className="w-10 h-10" />}
-            title="No transactions yet"
-            description="Your transaction history will appear here once you make your first transfer, mint, or burn."
+            title={query ? 'No matching transactions' : 'No transactions yet'}
+            description={query ? 'Try a different search term.' : 'Your transaction history will appear here once you make your first transfer, mint, or burn.'}
           />
         ) : (
           <div className="space-y-2">
-            {items.map((t) => (
+            {filtered.map((t) => (
               <Link key={t.transaction_id} href={`/transactions/${t.transaction_id}`} className="block">
                 <Card className="border-border p-4 flex items-center justify-between gap-3">
                   <div className="flex-1 min-w-0">

--- a/components/onboarding/onboarding-video.tsx
+++ b/components/onboarding/onboarding-video.tsx
@@ -37,7 +37,7 @@ export function OnboardingVideo({ src, poster, title }: OnboardingVideoProps) {
     // Render a safe fallback placeholder on the server
     return (
       <div className="relative w-full aspect-video overflow-hidden rounded-lg border border-border bg-muted flex items-center justify-center">
-        {poster && <img src={poster} alt={title || "Video poster"} className="object-cover w-full h-full opacity-50" />}
+        {poster && <img src={poster} alt={title || "Video poster"} fetchPriority="high" className="object-cover w-full h-full opacity-50" />}
       </div>
     );
   }

--- a/i18n/messages/ar.json
+++ b/i18n/messages/ar.json
@@ -1,0 +1,36 @@
+{
+  "home": {
+    "acbu": "ACBU",
+    "wallet_balance": "رصيد المحفظة",
+    "fiat": "عملة ورقية",
+    "simulated_usd_equivalent": "محاكاة · ما يعادل بالدولار",
+    "add_demo_funds": "إضافة أموال تجريبية",
+    "recent_activity": "النشاط الأخير",
+    "view_all": "عرض الكل",
+    "no_recent_activity": "لا يوجد نشاط حديث",
+    "send_money": "إرسال أموال",
+    "some_currencies_missing_rate": "بعض العملات لا تحتوي على سعر صرف",
+    "usd": "USD",
+    "approx_usd": "≈ USD",
+    "transaction_count": "{count, plural, zero {# معاملات} one {معاملة واحدة} two {معاملتان} few {# معاملات} many {# معاملة} other {# معاملة}}",
+    "session_count": "{count, plural, zero {# جلسات نشطة} one {جلسة نشطة واحدة} two {جلستان نشطتان} few {# جلسات نشطة} many {# جلسة نشطة} other {# جلسة نشطة}}"
+  },
+  "features": {
+    "send": {
+      "title": "إرسال",
+      "description": "تحويل الأموال"
+    },
+    "mint": {
+      "title": "سك",
+      "description": "إنشاء ACBU"
+    },
+    "simulated_bank": {
+      "title": "بنك محاكاة",
+      "description": "عملة ورقية تجريبية"
+    },
+    "rates": {
+      "title": "الأسعار",
+      "description": "أسعار السوق"
+    }
+  }
+}

--- a/i18n/messages/en-KE.json
+++ b/i18n/messages/en-KE.json
@@ -10,7 +10,9 @@
     "no_recent_activity": "No recent activity",
     "send_money": "Send money",
     "some_currencies_missing_rate": "Some currencies missing a rate",
-    "usd": "USD"
+    "usd": "USD",
+    "transaction_count": "{count, plural, one {# transaction} other {# transactions}}",
+    "session_count": "{count, plural, one {# active session} other {# active sessions}}"
   },
   "features": {
     "send": {

--- a/i18n/messages/en-NG.json
+++ b/i18n/messages/en-NG.json
@@ -10,7 +10,9 @@
     "no_recent_activity": "No recent activity",
     "send_money": "Send money",
     "some_currencies_missing_rate": "Some currencies missing a rate",
-    "usd": "USD"
+    "usd": "USD",
+    "transaction_count": "{count, plural, one {# transaction} other {# transactions}}",
+    "session_count": "{count, plural, one {# active session} other {# active sessions}}"
   },
   "features": {
     "send": {

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -11,7 +11,9 @@
     "send_money": "Send money",
     "some_currencies_missing_rate": "Some currencies missing a rate",
     "usd": "USD",
-    "approx_usd": "≈ USD"
+    "approx_usd": "≈ USD",
+    "transaction_count": "{count, plural, one {# transaction} other {# transactions}}",
+    "session_count": "{count, plural, one {# active session} other {# active sessions}}"
   },
   "features": {
     "send": {

--- a/i18n/messages/pl.json
+++ b/i18n/messages/pl.json
@@ -1,0 +1,36 @@
+{
+  "home": {
+    "acbu": "ACBU",
+    "wallet_balance": "Saldo portfela",
+    "fiat": "Waluta fiducjarna",
+    "simulated_usd_equivalent": "Symulacja · odpowiednik USD",
+    "add_demo_funds": "Dodaj środki demo",
+    "recent_activity": "Ostatnia aktywność",
+    "view_all": "Zobacz wszystkie",
+    "no_recent_activity": "Brak ostatniej aktywności",
+    "send_money": "Wyślij pieniądze",
+    "some_currencies_missing_rate": "Brak kursu dla niektórych walut",
+    "usd": "USD",
+    "approx_usd": "≈ USD",
+    "transaction_count": "{count, plural, one {# transakcja} few {# transakcje} many {# transakcji} other {# transakcji}}",
+    "session_count": "{count, plural, one {# aktywna sesja} few {# aktywne sesje} many {# aktywnych sesji} other {# aktywnych sesji}}"
+  },
+  "features": {
+    "send": {
+      "title": "Wyślij",
+      "description": "Przelej pieniądze"
+    },
+    "mint": {
+      "title": "Wybij",
+      "description": "Utwórz ACBU"
+    },
+    "simulated_bank": {
+      "title": "Symulowany bank",
+      "description": "Demo fiat"
+    },
+    "rates": {
+      "title": "Kursy",
+      "description": "Kursy rynkowe"
+    }
+  }
+}

--- a/i18n/messages/ru.json
+++ b/i18n/messages/ru.json
@@ -1,0 +1,36 @@
+{
+  "home": {
+    "acbu": "ACBU",
+    "wallet_balance": "Баланс кошелька",
+    "fiat": "Фиат",
+    "simulated_usd_equivalent": "Симуляция · эквивалент USD",
+    "add_demo_funds": "Добавить тестовые средства",
+    "recent_activity": "Последние операции",
+    "view_all": "Показать все",
+    "no_recent_activity": "Нет последних операций",
+    "send_money": "Отправить деньги",
+    "some_currencies_missing_rate": "Для некоторых валют нет курса",
+    "usd": "USD",
+    "approx_usd": "≈ USD",
+    "transaction_count": "{count, plural, one {# транзакция} few {# транзакции} many {# транзакций} other {# транзакции}}",
+    "session_count": "{count, plural, one {# активная сессия} few {# активных сессии} many {# активных сессий} other {# активных сессии}}"
+  },
+  "features": {
+    "send": {
+      "title": "Отправить",
+      "description": "Перевод средств"
+    },
+    "mint": {
+      "title": "Выпустить",
+      "description": "Создать ACBU"
+    },
+    "simulated_bank": {
+      "title": "Симулятор банка",
+      "description": "Тестовый фиат"
+    },
+    "rates": {
+      "title": "Курсы",
+      "description": "Рыночные курсы"
+    }
+  }
+}

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { getRequestConfig } from 'next-intl/server';
 
 // Can be imported from a shared config
-export const locales = ['en', 'en-NG', 'en-KE'] as const;
+export const locales = ['en', 'en-NG', 'en-KE', 'ar', 'ru', 'pl'] as const;
 export const defaultLocale = 'en';
 
  // @ts-ignore

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -97,7 +97,7 @@ async function request<T>(
     );
   }
   const url = path.startsWith('http') ? path : `${BASE}${path.startsWith('/') ? path : `/${path}`}`;
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = { 'Accept-Encoding': 'gzip' };
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json';
   }

--- a/lib/plural.ts
+++ b/lib/plural.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns the correct plural form for a count in the given locale.
+ * Falls back to locale from document if not specified.
+ *
+ * Usage:
+ *   plural(count, { one: '# session', other: '# sessions' }, 'en')
+ *   plural(count, { one: '# сессия', few: '# сессии', many: '# сессий', other: '# сессии' }, 'ru')
+ */
+export function plural(
+  count: number,
+  forms: Partial<Record<Intl.LDMLPluralRule, string>>,
+  locale?: string,
+): string {
+  const rule = new Intl.PluralRules(locale).select(count);
+  const template = forms[rule] ?? forms.other ?? String(count);
+  return template.replace('#', String(count));
+}


### PR DESCRIPTION
Closes #458

---

ix: request gzip-compressed responses in API client
  
  The API client was not sending an Accept-Encoding: gzip header, causing the backend to serve uncompressed JSON even to clients capable of decompression.
  This doubles bandwidth on mobile and slow connections.
  
  Change: Set Accept-Encoding: gzip as a default header on all requests in lib/api/client.ts.
  
  Why explicit? Browsers handle this automatically, but server-side Next.js (Node.js fetch) does not — making the header explicit ensures compression is
  negotiated in all rendering environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added client-side filtering for transactions.
  * Extended language support to include Arabic, Polish, and Russian.
  * Improved pluralization handling for transaction and session counts across all supported languages.

* **Performance Improvements**
  * Optimized asset loading with logo preload and video poster priority.
  * Enhanced API requests with compression support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->