### PR TITLE
fix(#520): address TypeScript suppression comments

### DIFF
--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -5,7 +5,7 @@ import { getRequestConfig } from 'next-intl/server';
 export const locales = ['en', 'en-NG', 'en-KE', 'ar', 'ru', 'pl'] as const;
 export const defaultLocale = 'en';
 
- // @ts-ignore
+ // @ts-expect-error: Suppressing type incompatibility between next-intl and Next.js version
 export default getRequestConfig(async ({ locale }) => {
   // Validate that the incoming `locale` parameter is valid
   if (!locales.includes(locale as any)) notFound();

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -5,7 +5,7 @@ import { getRequestConfig } from 'next-intl/server';
 export const locales = ['en', 'en-NG', 'en-KE', 'ar', 'ru', 'pl'] as const;
 export const defaultLocale = 'en';
 
- // @ts-expect-error: Suppressing type incompatibility between next-intl and Next.js version
+
 export default getRequestConfig(async ({ locale }) => {
   // Validate that the incoming `locale` parameter is valid
   if (!locales.includes(locale as any)) notFound();


### PR DESCRIPTION
Closes #520 

**Description:**
- Cleaned up TypeScript suppression comments.
- Removed an unused `// @ts-ignore` (which had been converted to `@ts-expect-error`) directive in `i18n/request.ts` that was causing a TypeScript compilation error (`TS2578`).

**Notes:**
After doing a full check of the codebase, no other `// @ts-expect-error` or `// @ts-ignore` comments without descriptions were found on this branch. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up a TypeScript suppression comment, improving code quality without changing behavior.
  * Locale handling and language-specific message loading continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->