### PR TITLE
 components.json outdated relative to installed shadcn/ui version

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -37,3 +37,30 @@ const buttonVariants = cva(
     },
   },
 )
+
+interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      type={type}
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,19 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Invariant function that throws an error if the condition is falsy.
+ * Use this instead of console.assert for invariant checks in production.
+ */
+export function invariant(
+  condition: unknown,
+  message?: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(message ?? "Invariant violation");
+  }
+}
+
 type NumberLocale = string | string[];
 
 function resolveNumberLocale(locale?: NumberLocale): NumberLocale | undefined {


### PR DESCRIPTION
his PR fixes an issue where buttons inside forms were defaulting to type="submit" , causing accidental form submissions when clicking secondary buttons like "Cancel" or "Add Recipient".



closes #503