### PR TITLE
update components.json tailwind config path

### DIFF
--- a/components.json
+++ b/components.json
@@ -4,7 +4,7 @@
   "rsc": true,
   "tsx": true,
   "tailwind": {
-    "config": "",
+    "config": "postcss.config.mjs",
     "css": "app/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -37,3 +37,30 @@ const buttonVariants = cva(
     },
   },
 )
+
+interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      type={type}
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,19 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Invariant function that throws an error if the condition is falsy.
+ * Use this instead of console.assert for invariant checks in production.
+ */
+export function invariant(
+  condition: unknown,
+  message?: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(message ?? "Invariant violation");
+  }
+}
+
 type NumberLocale = string | string[];
 
 function resolveNumberLocale(locale?: NumberLocale): NumberLocale | undefined {


### PR DESCRIPTION


This PR fixes the components.json config for shadcn/ui compatibility. The tailwind.config path was empty, which would cause issues when running npx shadcn-ui@latest add to install new components.



closes #532