### PR TITLE
feat: use native select on mobile for better touch experience

### DIFF
--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -5,11 +5,107 @@ import * as SelectPrimitive from '@radix-ui/react-select'
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 function Select({
+  children,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+}: React.ComponentProps<typeof SelectPrimitive.Root> & {
+  children?: React.ReactNode
+}) {
+  const isMobile = useIsMobile()
+  
+  // On mobile, use native select for better touch experience and native picker
+  // Only use native select when explicitly on mobile (true)
+  // Default to Radix UI during SSR/initial render (undefined) to avoid hydration mismatch
+  if (isMobile === true) {
+    return <NativeSelect {...props}>{children}</NativeSelect>
+  }
+  
+  // On desktop or during SSR, use Radix UI custom dropdown
+  return <SelectPrimitive.Root data-slot="select" {...props}>{children}</SelectPrimitive.Root>
+}
+
+// Native select for mobile devices
+function NativeSelect({
+  children,
+  value,
+  onValueChange,
+  disabled,
+  defaultValue,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root> & {
+  children?: React.ReactNode
+}) {
+  const [selectedValue, setSelectedValue] = React.useState(value || defaultValue || '')
+  
+  // Extract options from SelectItem children
+  const options = React.useMemo(() => {
+    const extractOptions = (node: React.ReactNode): Array<{ value: string; label: string }> => {
+      const result: Array<{ value: string; label: string }> = []
+      
+      React.Children.forEach(node, (child: React.ReactNode) => {
+        if (!React.isValidElement(child)) return
+        
+        // Check if it's a SelectItem by checking if it has value prop
+        if ('value' in child.props && child.props.value !== undefined) {
+          result.push({
+            value: String(child.props.value),
+            label: String(child.props.children || '')
+          })
+        }
+        
+        // Recursively handle nested children (e.g., SelectGroup)
+        if (child.props.children) {
+          result.push(...extractOptions(child.props.children))
+        }
+      })
+      
+      return result
+    }
+    
+    return extractOptions(children)
+  }, [children])
+  
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newValue = e.target.value
+    setSelectedValue(newValue)
+    onValueChange?.(newValue)
+  }
+  
+  // Sync with controlled value
+  React.useEffect(() => {
+    if (value !== undefined) {
+      setSelectedValue(value)
+    }
+  }, [value])
+  
+  return (
+    <div className="relative">
+      <select
+        value={selectedValue}
+        onChange={handleChange}
+        disabled={disabled}
+        className={cn(
+          "border-input data-[placeholder]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 appearance-none pr-8",
+        )}
+        {...props}
+      >
+        {options.length > 0 ? (
+          options.map((option: { value: string; label: string }) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))
+        ) : (
+          <option value="" disabled>
+            No options
+          </option>
+        )}
+      </select>
+      <ChevronDownIcon className="absolute right-3 top-1/2 -translate-y-1/2 size-4 opacity-50 pointer-events-none" />
+    </div>
+  )
 }
 
 function SelectGroup({


### PR DESCRIPTION


## Related Issues

* Close #463 – Element styled with Tailwind loses native mobile picker behavior

## Changes

### Mobile Select Accessibility Fix

* Updated `components/ui/select.tsx` to preserve native select behavior on mobile devices
* Restored iOS and Android native picker interfaces for touch-optimized selection
* Retained custom styling for desktop experiences while allowing native controls on mobile
* Improved accessibility by leveraging platform-native interaction patterns
* Ensured compatibility with screen readers and mobile assistive technologies

### Responsive Behavior

* Native picker displayed on mobile and touch devices
* Custom dropdown behavior maintained for desktop users
* Improved usability for long option lists on smaller screens

## Testing

* Verified native picker functionality on iOS Safari
* Verified native picker functionality on Android Chrome
* Tested keyboard navigation and accessibility behavior on desktop
* Confirmed no visual regressions in existing forms

## Impact

* Restores familiar mobile selection experience
* Improves accessibility and usability on touch devices
* Reduces interaction friction for mobile users
* Aligns form controls with platform best practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly select experience that uses the native browser picker on smaller screens.
  * Improved compatibility during initial page load by falling back to the original select behavior on desktop and server-rendered views.

* **Bug Fixes**
  * Better handles option rendering when select items are nested, and shows a clear “No options” state when none are available.
  * Keeps the selected value in sync when the current selection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->