### PR TITLE
fix: add apple-mobile-web-app-capable meta; align Playwright and Vitest configs for CI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -96,6 +96,8 @@ export default async function RootLayout({
           this resource on non-print (screen/mobile) page loads.
         */}
         <link rel="stylesheet" href="/print.css" media="print" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <script
           nonce={nonce}
           dangerouslySetInnerHTML={{

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   reporter: 'html',
   
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -22,9 +22,11 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    // Build then start to ensure assets are available in CI and cold starts
+    command: process.env.PW_BUILD_AND_START ? process.env.PW_BUILD_AND_START : 'npm run build && npm run start',
+    url: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120000,
+    // Increase timeout for cold starts (build + start) in CI
+    timeout: process.env.CI ? 300000 : 120000,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,9 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     include: ['**/*.test.{ts,tsx}'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**'],
+    coverage: {
+      provider: 'istanbul',
+      reporter: ['text', 'lcov'],
+    },
   },
 })


### PR DESCRIPTION
Closes #453 
Closes #516 
Closes #524 
Closes #535 

This PR fixes several frontend issues related to iOS standalone behavior and CI test consistency:

- Adds `apple-mobile-web-app-capable` and `apple-mobile-web-app-status-bar-style` meta tags in `app/layout.tsx` to enable proper iOS "Add to Home Screen" standalone mode. (Addresses #516)
- Updates `playwright.config.ts` to use `PLAYWRIGHT_BASE_URL` when provided, run a build+start in CI, and increase the webServer timeout to allow cold builds to finish. (Addresses #524)
- Sets Vitest coverage provider to `istanbul` in `vitest.config.ts` so local runs match CI coverage behavior and avoid threshold mismatches. (Addresses #535)

Note: Issue #453 references `.env.example` in the backend repository (acbu-backend). That file isn't present in this frontend repo, so it should be addressed in the backend repository.

Files changed:
- app/layout.tsx
- playwright.config.ts
- vitest.config.ts

Please review and let me know if you'd like any adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the app’s behavior on Apple mobile devices for a more app-like experience.
* **Chores**
  * Updated browser test setup to better support different environments and CI runs.
  * Enabled test coverage reporting for clearer quality tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->