### PR TITLE
Add user menu component with logout button that avoids prefetching

### DIFF
--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { User, Settings, Shield, Eye, Building2, Clock, HelpCircle, LogOut } from 'lucide-react';
+import { useAuth } from '@/contexts/auth-context';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+
+interface MenuItem {
+  title: string;
+  icon: React.ElementType;
+  href: string;
+}
+
+const menuItems: MenuItem[] = [
+  { title: 'Profile', icon: User, href: '/me/profile' },
+  { title: 'Settings', icon: Settings, href: '/me/settings' },
+  { title: 'Two-Factor Auth', icon: Shield, href: '/me/settings/security' },
+  { title: 'Wallet', icon: Eye, href: '/wallet' },
+  { title: 'Simulated Bank', icon: Building2, href: '/fiat' },
+];
+
+const supportItems: MenuItem[] = [
+  { title: 'Activity History', icon: Clock, href: '/activity' },
+  { title: 'Help Center', icon: HelpCircle, href: '/help' },
+];
+
+interface UserMenuProps {
+  displayName?: string;
+}
+
+export function UserMenu({ displayName }: UserMenuProps) {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const initials = (displayName?.slice(0, 2) || 'AB').toUpperCase();
+
+  const handleLogout = async () => {
+    await logout();
+    router.replace('/auth/signin');
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="relative h-10 w-10 rounded-full">
+          <Avatar className="h-10 w-10">
+            <AvatarFallback className="bg-gradient-to-br from-primary to-secondary text-white">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56" align="end">
+        <DropdownMenuLabel>
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm font-medium leading-none">{displayName || 'Account'}</p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {menuItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <DropdownMenuItem key={item.href} asChild>
+              <a href={item.href} className="cursor-pointer">
+                <Icon className="mr-2 h-4 w-4" />
+                <span>{item.title}</span>
+              </a>
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuSeparator />
+        {supportItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <DropdownMenuItem key={item.href} asChild>
+              <a href={item.href} className="cursor-pointer">
+                <Icon className="mr-2 h-4 w-4" />
+                <span>{item.title}</span>
+              </a>
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive cursor-pointer"
+          onSelect={handleLogout}
+        >
+          <LogOut className="mr-2 h-4 w-4" />
+          <span>Sign Out</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
Created components/user-menu.tsx with:

Dropdown menu triggered by an avatar button showing user initials
Navigation links to Profile, Settings, Two-Factor Auth, Wallet, Simulated Bank, Activity History, and Help Center using <a> tags (not Next.js Link) to avoid prefetching
Logout button using onSelect handler with the auth context's logout() function (not a Link) to prevent session invalidation from prefetch requests
Avatar component from existing UI library for the trigger button
The logout uses an event handler instead of a Link component, so no prefetch request will be made to the logout endpoint.

closes #485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user account menu with an avatar, initials, and account name display.
  * Introduced dropdown links for quick access to menu and support options.
  * Added a sign-out action that logs the user out and returns them to the sign-in page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->