### PR TITLE
chore: enforce Tailwind class sorting with Prettier plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["cn", "clsx", "cva"]
+}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "postcss": "^8.5",
     "postcss-preset-env": "^11.3.1",
     "prettier": "^3.7.4",
+    "prettier-plugin-tailwindcss": "^0.8.0",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.9",
     "tw-animate-css": "1.3.3",
@@ -131,6 +132,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
+      "prettier --write",
       "eslint --fix"
     ],
     "*.{json,css,md}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       prettier:
         specifier: ^3.7.4
         version: 3.8.4
+      prettier-plugin-tailwindcss:
+        specifier: ^0.8.0
+        version: 0.8.0(prettier@3.8.4)
       tailwindcss:
         specifier: ^4.1.9
         version: 4.1.18
@@ -5299,6 +5302,61 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-tailwindcss@0.8.0:
+    resolution: {integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.8.4:
     resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
@@ -12159,6 +12217,10 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-tailwindcss@0.8.0(prettier@3.8.4):
+    dependencies:
+      prettier: 3.8.4
 
   prettier@3.8.4: {}
 


### PR DESCRIPTION
## Description

This PR adds automated Tailwind CSS class sorting using the official `prettier-plugin-tailwindcss` plugin.

Without a standardized class ordering mechanism, Tailwind utility classes can appear in different orders depending on the contributor, creating noisy pull request diffs and making reviews harder. This change ensures a consistent ordering strategy across the codebase.

### Changes Made

* Added `prettier-plugin-tailwindcss` as a development dependency
* Created a Prettier configuration file to enable automatic Tailwind class sorting
* Configured support for common utility wrappers:

  * `cn`
  * `clsx`
  * `cva`
* Updated `lint-staged` configuration to run Prettier on JavaScript and TypeScript files before ESLint
* Updated lockfile to reflect dependency changes

### Benefits

* Consistent Tailwind class ordering across contributors
* Cleaner pull request diffs
* Reduced formatting-related review comments
* Improved developer experience during collaboration
* Better alignment with Tailwind's recommended tooling

### Validation

* Verified the Prettier plugin loads successfully
* Confirmed Tailwind classes are automatically sorted
* Confirmed no application runtime code was modified
* Confirmed no UI behavior changes were introduced

### Notes

* This change is limited to development tooling and formatting behavior.
* No production dependencies were added.
* No application logic, styling behavior, or runtime functionality was modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code formatting consistency by adding Tailwind-aware Prettier support.
  * Updated staged file checks so JavaScript, TypeScript, and React files are formatted before lint fixes run.
  * Recognizes common class-combining helper names for better automatic class sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->