### PR TITLE
feat: add data-testid attributes to key interactive elements - Resolv…

### DIFF
--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -20,7 +20,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   return (
     <div className="min-h-screen bg-background flex flex-col">
 
-      <main className={`flex-1 ${!isPublic ? 'pb-24' : ''}`}>
+      <main data-testid="app-main-content" className={`flex-1 ${!isPublic ? 'pb-24' : ''}`}>
         <PageTransition>{children}</PageTransition>
       </main>
 

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -48,7 +48,7 @@ export class ErrorBoundary extends Component<Props, State> {
       const isAppLevel = this.props.level === 'app';
       const isPageLevel = this.props.level === 'page';
       return (
-        <div className={`flex flex-col items-center justify-center gap-4 p-6 text-center ${
+        <div data-testid="error-boundary-fallback" className={`flex flex-col items-center justify-center gap-4 p-6 text-center ${
           isAppLevel ? 'min-h-screen' : isPageLevel ? 'min-h-[400px]' : 'min-h-[200px]'
         }`}>
           <div className="rounded-full bg-red-100 p-3">

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -82,6 +82,7 @@ export function MobileNav() {
           return (
             <button
               key={item.href}
+              data-testid={`nav-${item.name.toLowerCase()}`}
               onClick={() => handleNav(item.href)}
               aria-label={item.name}
               disabled={isPending}

--- a/components/wallet-setup-modal.tsx
+++ b/components/wallet-setup-modal.tsx
@@ -215,6 +215,7 @@ export function WalletSetupModal() {
         {!option ? (
           <div className="space-y-4 py-4">
             <Button
+              data-testid="generate-wallet-button"
               onClick={() => {
                 // Always generate a fresh key when user explicitly chooses "Generate New Wallet"
                 const kp = Keypair.random();
@@ -231,6 +232,7 @@ export function WalletSetupModal() {
             </Button>
 
             <Button
+              data-testid="import-wallet-button"
               onClick={() => setOption(2)}
               className="w-full h-auto py-4 flex flex-col items-center"
               variant="outline"


### PR DESCRIPTION
## Add data-testid attributes for E2E test stability

### Problem
E2E tests rely on fragile selectors (CSS classes, text content, XPath) that break during UI refactors.

### Solution
Added `data-testid` attributes to key interactive elements:
- Main content area: `app-main-content`
- Error boundary fallback: `error-boundary-fallback`
- Navigation buttons: `nav-home`, `nav-send`, `nav-mint`, `nav-business`, `nav-wallet`, `nav-me`
- Wallet setup buttons: `generate-wallet-button`, `import-wallet-button`

### Testing
- Verified all data-testid attributes are present in rendered components
- Confirmed selectors are resilient to CSS class changes

Closes #525
