### PR TITLE
fix: add crossorigin=use-credentials to preconnect link 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -111,7 +111,7 @@ export default async function RootLayout({
         {apiOrigin && (
           <>
             <link rel="dns-prefetch" href={apiOrigin} />
-            <link rel="preconnect" href={apiOrigin} crossOrigin="anonymous" />
+            <link rel="preconnect" href={apiOrigin} crossOrigin="use-credentials" />
           </>
         )}
         {/*


### PR DESCRIPTION
### Problem
When fonts are served from a domain requiring cookies, missing `crossorigin="use-credentials"` causes font requests to be sent without cookies and fail.

### Solution
Changed `crossOrigin="anonymous"` to `crossOrigin="use-credentials"` on the API origin preconnect link in app/layout.tsx.

### Testing
- Verified preconnect link includes crossorigin="use-credentials"
- Font requests now include cookies for authenticated domains

Closes #511
