### PR TITLE
fix: add as prop to next/link, @/ aliases, and fetchpriority hints

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -254,7 +254,7 @@ export default function Home() {
                       )}
                       {!fiatAccounts.length && (
                         <p className="text-sm font-normal text-muted-foreground mt-1 md:text-base">
-                          <Link href="/fiat" className="text-primary font-medium underline-offset-2 hover:underline">
+                          <Link href="/fiat" as="/fiat" className="text-primary font-medium underline-offset-2 hover:underline">
                             {t('add_demo_funds')}
                           </Link>
                         </p>
@@ -280,7 +280,7 @@ export default function Home() {
             {features.map((feature) => {
               const Icon = feature.icon;
               return (
-                <Link key={feature.href} href={feature.href} className="block">
+                <Link key={feature.href} href={feature.href} as={feature.href} className="block">
                   <div className={`${feature.color} rounded-lg border border-border/50 p-4 h-full transition-all active:scale-95 md:p-5`}>
                     <Icon className={`w-6 h-6 ${feature.iconColor} mb-2 md:w-7 md:h-7 md:mb-3`} />
                     <h3 className="text-sm font-semibold text-foreground mb-0.5 md:text-base">{feature.title}</h3>
@@ -294,7 +294,7 @@ export default function Home() {
           <div className="space-y-3 md:space-y-4">
             <div className="flex items-center justify-between px-1">
               <h3 className="text-sm font-semibold text-foreground md:text-base">{t('recent_activity')}</h3>
-              <Link href="/activity" className="text-xs text-primary font-medium md:text-sm">{t('view_all')}</Link>
+              <Link href="/activity" as="/activity" className="text-xs text-primary font-medium md:text-sm">{t('view_all')}</Link>
             </div>
             {error && <p className="text-sm text-destructive">{error}</p>}
             {loading ? (
@@ -304,7 +304,7 @@ export default function Home() {
                 icon={<Clock className="w-10 h-10" />}
                 title={t('no_recent_activity')}
                 action={
-                  <Link href="/send" className="text-xs text-primary font-medium">
+                  <Link href="/send" as="/send" className="text-xs text-primary font-medium">
                     {t('send_money')}
                   </Link>
                 }
@@ -312,7 +312,7 @@ export default function Home() {
             ) : (
               <div className="space-y-2 md:space-y-3">
                 {transactions.slice(0, 5).map((t) => (
-                  <Link key={t.transaction_id} href={`/transactions/${t.transaction_id}`} className="block rounded-lg border border-border bg-card p-3 transition-colors active:bg-muted md:p-4">
+                  <Link key={t.transaction_id} href={`/transactions/${t.transaction_id}`} as={`/transactions/${t.transaction_id}`} className="block rounded-lg border border-border bg-card p-3 transition-colors active:bg-muted md:p-4">
                     <div className="flex items-center gap-3 mb-2">
                       <div
                         className={`p-2 rounded-full flex-shrink-0 md:p-3 ${

--- a/hooks/use-balance.ts
+++ b/hooks/use-balance.ts
@@ -61,7 +61,7 @@ export function useBalance(): UseBalanceReturn {
     setError('');
 
     userApi
-      .getBalance(opts)
+      .getBalance({ ...opts, priority: 'high' })
       .then((data) => {
         if (cancelled) return;
         const raw = data.balance;

--- a/lib/__tests__/api-error.test.ts
+++ b/lib/__tests__/api-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mapApiError } from '../../hooks/use-api-error';
+import { mapApiError } from '@/hooks/use-api-error';
 import { getApiErrorMessage } from '../api/client';
 import type { ApiError } from '../api/client';
 

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,4 +1,4 @@
-import { normalizeUsername } from '../utils';
+import { normalizeUsername } from '@/lib/utils';
 import { post } from './client';
 import type { RequestOptions } from './client';
 import type { SigninResponse, SigninRequires2FA } from '@/types/api';

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -81,6 +81,8 @@ export interface RequestOptions {
   retries?: number;
   /** Base delay time in milliseconds for exponential backoff retry logic. */
   retryDelay?: number;
+  /** Fetch Priority API hint. Pass 'high' for above-the-fold critical requests. */
+  priority?: RequestPriority;
 }
 
 export interface ApiError extends Error {
@@ -139,7 +141,8 @@ async function request<T>(
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal,
-      credentials: 'include', // Include httpOnly cookies in all requests
+      credentials: 'include',
+      ...(opts.priority !== undefined && { priority: opts.priority }),
     });
   } catch (error) {
     clearTimeout(timeoutId);

--- a/lib/stellar/trustlines.ts
+++ b/lib/stellar/trustlines.ts
@@ -6,7 +6,7 @@ import {
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
 import { acbuAsset, demoFiatAsset } from "./demo-fiat";
-import { getAssetsConfig } from "../api/config";
+import { getAssetsConfig } from "@/lib/api/config";
 import type { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
 import { logger } from '@/lib/logger';
 


### PR DESCRIPTION
- Closes #501 : add as={href} to all next/link components in app/[locale]/page.tsx so Next.js can match the display URL and reuse shared layouts on client transitions (e.g. /send ↔ /mint)
- Closes #502 : replace cross-directory relative imports with @/ alias in lib/api/auth.ts, lib/stellar/trustlines.ts, and lib/__tests__/api-error.test.ts
- Closes #500 : expose priority?: RequestPriority on RequestOptions and pass it through to fetch(); use-balance passes priority: high so the critical balance request is not deprioritised behind images/fonts