### PR TITLE
fix(#519): standardise exports to named-only, add barrel index files

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Barrel export for /components
+ *
+ * All public component exports are named exports.
+ * Next.js pages (app/) remain default-exported as required by the framework.
+ */
+
+// Root-level components
+export { AppLayout } from './app-layout';
+export { ErrorBoundary } from './error-boundary';
+export { ErrorTestTrigger } from './error-test-trigger';
+export { GlobalErrorHandler } from './global-error-handler';
+export { MobileNav } from './mobile-nav';
+export { OfflineIndicator } from './offline-indicator';
+export { PageTransition } from './page-transition';
+export { SessionExpiryWarning } from './session-expiry-warning';
+export { ThemeProvider } from './theme-provider';
+export { UserMenu } from './user-menu';
+export { WalletSetupModal } from './wallet-setup-modal';
+
+// Layout
+export { AuthGuard } from './layout/auth-guard';
+export { PageContainer } from './layout/page-container';
+
+// Navigation
+export { BackButton } from './navigation/BackButton';
+
+// Onboarding
+export { OnboardingAudio, OnboardingVideo } from './onboarding/media';
+export { OnboardingVideo as OnboardingVideoPlayer } from './onboarding/onboarding-video';
+
+// Chat
+export { ChatMessage } from './chat/ChatMessage';

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Barrel export for /contexts
+ *
+ * All exports are named exports for consistent import style:
+ *   import { useAuth, AuthProvider } from '@/contexts'
+ */
+
+export { AuthProvider, useAuth } from './auth-context';
+export { I18nProvider, useI18n } from './i18n-context';
+export { NavigationGuardProvider, useNavigationGuard } from './navigation-guard-context';

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Barrel export for /hooks
+ *
+ * All exports are named exports for consistent import style:
+ *   import { useAuth, useBalance } from '@/hooks'
+ */
+
+export { useApiOpts } from './use-api';
+export { mapApiError, useApiError } from './use-api-error';
+export { useBalance } from './use-balance';
+export { useDebounce } from './use-debounce';
+export { useFocusTrap } from './use-focus-trap';
+export { useIsMobile } from './use-mobile';
+export { useNavigationGuard } from './use-navigation-guard';
+export { useOnlineStatus } from './use-online-status';
+export { useScrollRestoration } from './use-scroll-restoration';
+export { useSessionGuard } from './use-session-guard';
+export { useToast, toast } from './use-toast';

--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -12,4 +12,4 @@ export function isSafeRedirect(target: string | null, baseOrigin?: string): stri
     }
 }
 
-export default isSafeRedirect;
+


### PR DESCRIPTION
- Remove duplicate `export default` from lib/redirect.ts; keep only named export `isSafeRedirect` (no callers used the default import)
- Add components/index.ts: named re-exports for all public components; aliases OnboardingVideo from onboarding/media as OnboardingVideoPlayer to avoid conflict with onboarding/onboarding-video
- Add hooks/index.ts: named re-exports for all hooks
- Add contexts/index.ts: named re-exports for all context providers/hooks

Next.js pages in app/ continue to use `export default` as required by the framework — that is intentional and correct.

closes #519 