### PR TITLE
chore: add MIT license field and LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pi-Defi-world
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "my-v0-project",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Fix #686: No LICENSE field in package.json

Summary
Adds a `license` field to `package.json` and a `LICENSE` file at the repo root. The frontend previously had no license declared, while the backend (Apache-2.0) and ZK/smart-contract side (MIT) both have one.

Changes
- `package.json`: added `"license": "MIT"`
- `LICENSE`: new file at repo root with the full MIT license text

Why MIT
- MIT is the conventional default for JS/TS frontend packages
- Matches the existing MIT license already used on the ZK side of the project
- Permissive, no conflict with the backend's Apache-2.0 license

Testing
No functional code touched — this is metadata/documentation only. Verified `package.json` still parses as valid JSON after the change.

Checklist
- [x] `license` field present in `package.json`
- [x] `LICENSE` file present at repo root
- [x] No other files modified

Closes #686