### PR TITLE
fix(hooks): guard useApiError timeout with explicit ref (#688)

### DIFF
--- a/hooks/__tests__/use-api-error.test.ts
+++ b/hooks/__tests__/use-api-error.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { useApiError } from '../use-api-error';
-import type { ApiError } from '@/lib/api/client';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useApiError } from "../use-api-error";
+import type { ApiError } from "@/lib/api/client";
 
 function makeApiError(status: number, message: string): ApiError {
   const err = new Error(message) as ApiError;
@@ -9,75 +9,142 @@ function makeApiError(status: number, message: string): ApiError {
   return err;
 }
 
-describe('useApiError', () => {
-  it('starts with an empty error string', () => {
+describe("useApiError", () => {
+  it("starts with an empty error string", () => {
     const { result } = renderHook(() => useApiError());
-    expect(result.current.uiError?.message ?? '').toBe('');
+    expect(result.current.uiError?.message ?? "").toBe("");
   });
 
-  it('clearError resets the error to empty', () => {
+  it("clearError resets the error to empty", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(new Error('oops')));
-    expect(result.current.uiError?.message ?? '').not.toBe('');
+    act(() => result.current.setApiError(new Error("oops")));
+    expect(result.current.uiError?.message ?? "").not.toBe("");
     act(() => result.current.clearError());
-    expect(result.current.uiError?.message ?? '').toBe('');
+    expect(result.current.uiError?.message ?? "").toBe("");
   });
 
-  it('setError sets an arbitrary message', () => {
+  it("setError sets an arbitrary message", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(new Error('custom message')));
-    expect(result.current.uiError?.message ?? '').toBe('custom message');
+    act(() => result.current.setApiError(new Error("custom message")));
+    expect(result.current.uiError?.message ?? "").toBe("custom message");
   });
 
   // --- handleError maps the three special codes ---
 
-  it('handleError maps HTTP 429 to the rate-limit message', () => {
+  it("handleError maps HTTP 429 to the rate-limit message", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(makeApiError(429, 'rate limited')));
-    expect(result.current.uiError?.message ?? '').toBe(
-      'Too many requests. Please wait a moment before trying again.',
+    act(() => result.current.setApiError(makeApiError(429, "rate limited")));
+    expect(result.current.uiError?.message ?? "").toBe(
+      "Too many requests. Please wait a moment before trying again.",
     );
   });
 
-  it('handleError maps HTTP 503 to the service-unavailable message', () => {
+  it("handleError maps HTTP 503 to the service-unavailable message", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(makeApiError(503, 'down')));
-    expect(result.current.uiError?.message ?? '').toBe(
-      'Our payment processor is temporarily down. Your funds are safe.',
+    act(() => result.current.setApiError(makeApiError(503, "down")));
+    expect(result.current.uiError?.message ?? "").toBe(
+      "Our payment processor is temporarily down. Your funds are safe.",
     );
   });
 
-  it('handleError maps HTTP 402 to the payment-required message', () => {
+  it("handleError maps HTTP 402 to the payment-required message", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(makeApiError(402, 'upgrade')));
-    expect(result.current.uiError?.message ?? '').toBe(
-      'Insufficient balance or payment required.',
+    act(() => result.current.setApiError(makeApiError(402, "upgrade")));
+    expect(result.current.uiError?.message ?? "").toBe(
+      "Insufficient balance or payment required.",
     );
   });
 
   // --- handleError falls back for other codes ---
 
-  it('handleError passes through the message for 400', () => {
+  it("handleError passes through the message for 400", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(makeApiError(400, 'bad request')));
-    expect(result.current.uiError?.message ?? '').toBe('bad request');
+    act(() => result.current.setApiError(makeApiError(400, "bad request")));
+    expect(result.current.uiError?.message ?? "").toBe("bad request");
   });
 
-  it('handleError passes through the message for 500', () => {
+  it("handleError passes through the message for 500", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(makeApiError(500, 'server error')));
-    expect(result.current.uiError?.message ?? '').toBe('server error');
+    act(() => result.current.setApiError(makeApiError(500, "server error")));
+    expect(result.current.uiError?.message ?? "").toBe("server error");
   });
 
-  it('handleError handles a plain Error with no status', () => {
+  it("handleError handles a plain Error with no status", () => {
     const { result } = renderHook(() => useApiError());
-    act(() => result.current.setApiError(new Error('network failure')));
-    expect(result.current.uiError?.message ?? '').toBe('network failure');
+    act(() => result.current.setApiError(new Error("network failure")));
+    expect(result.current.uiError?.message ?? "").toBe("network failure");
   });
 
-  it('handleError handles null gracefully', () => {
+  it("handleError handles null gracefully", () => {
     const { result } = renderHook(() => useApiError());
     act(() => result.current.setApiError(null as unknown));
-    expect(result.current.uiError?.message ?? '').toBe('Something went wrong. Please try again.');
+    expect(result.current.uiError?.message ?? "").toBe(
+      "Something went wrong. Please try again.",
+    );
+  });
+
+  // --- isSubmitDisabled timer behavior (issue #688) ---
+
+  describe("isSubmitDisabled timer", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("disables submit for the duration given by a 429 response, then re-enables", () => {
+      const { result } = renderHook(() => useApiError());
+      act(() => result.current.setApiError(makeApiError(429, "rate limited")));
+      expect(result.current.isSubmitDisabled).toBe(true);
+
+      act(() => vi.advanceTimersByTime(30_000));
+      expect(result.current.isSubmitDisabled).toBe(false);
+    });
+
+    it("does not re-enable early when a second 429 arrives before the first window elapses", () => {
+      const { result } = renderHook(() => useApiError());
+
+      act(() => result.current.setApiError(makeApiError(429, "first")));
+      act(() => vi.advanceTimersByTime(10_000)); // 10s into the first 30s window
+
+      // A second rapid error resets the disable window from "now".
+      act(() => result.current.setApiError(makeApiError(429, "second")));
+      expect(result.current.isSubmitDisabled).toBe(true);
+
+      // Enough time to have fired the FIRST (now-superseded) timer, but not
+      // the second one — submit must still be disabled.
+      act(() => vi.advanceTimersByTime(20_000));
+      expect(result.current.isSubmitDisabled).toBe(true);
+
+      // Now clear the remaining time on the second window.
+      act(() => vi.advanceTimersByTime(10_000));
+      expect(result.current.isSubmitDisabled).toBe(false);
+    });
+
+    it("handles many rapid successive updates without leaving stale timers enabled", () => {
+      const { result } = renderHook(() => useApiError());
+
+      act(() => {
+        result.current.setApiError(makeApiError(429, "first"));
+        result.current.setApiError(makeApiError(429, "second"));
+      });
+      expect(result.current.isSubmitDisabled).toBe(true);
+      expect(vi.getTimerCount()).toBe(1); // stale timers were cleared, not stacked
+
+      act(() => vi.advanceTimersByTime(30_000));
+      expect(result.current.isSubmitDisabled).toBe(false);
+    });
+
+    it("clearError immediately re-enables submit and cancels the pending timer", () => {
+      const { result } = renderHook(() => useApiError());
+      act(() => result.current.setApiError(makeApiError(429, "rate limited")));
+      expect(result.current.isSubmitDisabled).toBe(true);
+
+      act(() => result.current.clearError());
+      expect(result.current.isSubmitDisabled).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 });

--- a/hooks/use-api-error.ts
+++ b/hooks/use-api-error.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { ApiError } from "@/lib/api/client";
 
 /**
@@ -36,9 +36,7 @@ export function mapApiError(err: unknown): UIError | null {
   if (err == null) return null;
 
   const status =
-    (err as ApiError).status ??
-    (err as ApiErrorResponse).status ??
-    undefined;
+    (err as ApiError).status ?? (err as ApiErrorResponse).status ?? undefined;
 
   const rawMessage =
     err instanceof Error
@@ -95,7 +93,18 @@ export function useApiError() {
   const [submitDisabledUntil, setSubmitDisabledUntil] = useState<number>(0);
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(false);
 
+  // Tracks the currently-scheduled timeout so it can be explicitly cancelled
+  // as defense-in-depth alongside the effect cleanup ordering.
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
+    // Always clear any timer left over from a previous run before doing
+    // anything else — defensive, in addition to the cleanup fn below.
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
     if (submitDisabledUntil <= 0) {
       setIsSubmitDisabled(false);
       return;
@@ -106,10 +115,17 @@ export function useApiError() {
       return;
     }
     setIsSubmitDisabled(true);
-    const timeout = setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
       setIsSubmitDisabled(false);
     }, submitDisabledUntil - now);
-    return () => clearTimeout(timeout);
+
+    return () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
   }, [submitDisabledUntil]);
 
   const setApiError = useCallback((err: unknown) => {


### PR DESCRIPTION
Closes #688.

React already runs an effect's cleanup before the next effect executes, so the original race condition isn't reproducible in practice. This change adds an explicit timeoutRef that's cleared before scheduling a new timeout as an extra safeguard and to make the timeout lifecycle easier to follow.

Added tests covering rapid consecutive 429 responses to verify that only one timeout is active at a time and that timers are cleaned up correctly.

13/14 tests pass. The remaining failure (handleError handles null gracefully) is a pre-existing null-input handling issue unrelated to this change. This PR does not modify that code path.

The current dev branch is also failing CI during pnpm install --frozen-lockfile with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH, which is unrelated to this change. This PR only modifies hooks/use-api-error.ts and hooks/__tests__/use-api-error.test.ts.