### PR TITLE
fix: accessibility, URL validation, and tsconfig target improvements

### DIFF
--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -91,7 +91,26 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const forwardResponse = await fetch(intakeUrl, {
+  let parsedIntakeUrl: URL;
+  try {
+    parsedIntakeUrl = new URL(intakeUrl);
+  } catch {
+    console.error('[Support] SUPPORT_INTAKE_URL is not a valid URL:', intakeUrl);
+    return NextResponse.json(
+      { error: 'Support intake is misconfigured. Please contact support@acbu.io directly.' },
+      { status: 503 },
+    );
+  }
+
+  if (parsedIntakeUrl.protocol !== 'https:') {
+    console.error('[Support] SUPPORT_INTAKE_URL must use HTTPS:', intakeUrl);
+    return NextResponse.json(
+      { error: 'Support intake is misconfigured. Please contact support@acbu.io directly.' },
+      { status: 503 },
+    );
+  }
+
+  const forwardResponse = await fetch(parsedIntakeUrl.toString(), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/components/offline-indicator.tsx
+++ b/components/offline-indicator.tsx
@@ -17,7 +17,7 @@ export function OfflineIndicator() {
   if (!mounted || online) return null;
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-2 bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground shadow-md">
+    <div role="alert" className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-2 bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground shadow-md">
       <WifiOff className="h-4 w-4" />
       <span>{t('offline.youAreOffline')}</span>
     </div>

--- a/components/session-expiry-warning.tsx
+++ b/components/session-expiry-warning.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import { AlertCircle, LogIn } from 'lucide-react';
+import { AlertCircle, LogIn, X } from 'lucide-react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -85,7 +85,7 @@ export function SessionExpiryWarning({
           aria-label="Dismiss warning"
           className="shrink-0 rounded p-1 hover:bg-yellow-200 dark:hover:bg-yellow-800"
         >
-          ✕
+          <X className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "esnext"
     ],
     "allowJs": true,
-    "target": "ES6",
+    "target": "ES2020",
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
- #663 Replace unicode dismiss button (✕) with lucide X icon in session-expiry-warning.tsx for consistent cross-platform rendering
- #664 Add role='alert' to offline-indicator.tsx for immediate screen reader announcement
- #703 Validate SUPPORT_INTAKE_URL with URL parsing and HTTPS protocol check before use as fetch target
- #671 Update tsconfig target from ES6 to ES2020 to reduce polyfill bloat and enable modern compiler output

## Description

<!-- What does this PR do? Provide a clear summary of the changes. -->

## Why

<!-- Why is this change needed? Link related issues with "Closes #123" or "Fixes #456". -->

## How to test

<!-- Step-by-step instructions so reviewers can verify the change locally. -->

1. 
2. 
3. 

## Screenshots / Recordings

<!-- Attach before/after screenshots or screen recordings for UI changes. Delete this section if not applicable. -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] Added or updated tests (if applicable)
- [ ] No new TypeScript or lint errors (`pnpm typecheck && pnpm lint`)
- [ ] Tested on mobile viewport (if UI change)
- [ ] Accessibility checked (keyboard navigation, screen reader)
closes #663 
closes #664 
closes #671 
closes #703 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support request handling when the configured intake address is missing, invalid, or insecure.
  - Invalid support configurations now return a clear service-unavailable message instead of failing unexpectedly.

- **Accessibility**
  - Improved screen-reader support for the offline notification.

- **Style**
  - Updated the session-expiry dismissal control with a consistent close icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->