### PR TITLE
fix(#646): remove nested html/body from [locale]/layout.tsx

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,13 +1,6 @@
 import React, { Suspense } from "react"
-import type { Metadata, Viewport } from 'next'
-import { Analytics } from '@vercel/analytics/next'
-import { AuthProvider } from '@/contexts/auth-context'
 import { NavigationGuardProvider } from '@/contexts/navigation-guard-context'
-import { ErrorBoundary } from '@/components/error-boundary'
-import '../globals.css'
 import { AuthGuard } from '@/components/layout/auth-guard';
-import { AppLayout } from '@/components/app-layout';
-import { WalletSetupModal } from '@/components/wallet-setup-modal';
 import { Spinner } from '@/components/ui/spinner';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
@@ -20,73 +13,28 @@ function TranslationsFallback() {
   );
 }
 
-export const metadata: Metadata = {
-  title: 'ACBU - P2P Transfers',
-  description: 'Send and receive money securely with ACBU',
-  generator: 'v0.app',
-  icons: {
-    icon: [
-      {
-        url: '/icon-light-32x32.png',
-        media: '(prefers-color-scheme: light)',
-      },
-      {
-        url: '/icon-dark-32x32.png',
-        media: '(prefers-color-scheme: dark)',
-      },
-      {
-        url: '/icon.svg',
-        type: 'image/svg+xml',
-      },
-    ],
-    apple: '/apple-icon.png',
-  },
-}
-
-export const viewport: Viewport = {
-  width: 'device-width',
-  initialScale: 1,
-  maximumScale: 1,
-}
-
-export default async function RootLayout({
+export default async function LocaleLayout({
   children,
   params,
 }: Readonly<{
   children: React.ReactNode
   params: Promise<{ locale: string }>
 }>) {
-  const { locale } = await params;
+  // params is needed to satisfy Next.js dynamic segment typing; locale is
+  // resolved by next-intl's request config so getMessages() picks it up
+  // automatically without us having to forward it explicitly.
+  await params;
   const messages = await getMessages();
 
   return (
-      <html lang={locale} suppressHydrationWarning>
-      <head>
-        {/* Preconnect to third-party domains to eliminate DNS+TCP latency (#509) */}
-        <link rel="preconnect" href="https://va.vercel-scripts.com" crossOrigin="anonymous" />
-        <link rel="dns-prefetch" href="https://va.vercel-scripts.com" />
-        {process.env.NEXT_PUBLIC_API_BASE_URL && (
-          <>
-            <link rel="preconnect" href={new URL(process.env.NEXT_PUBLIC_API_BASE_URL).origin} crossOrigin="anonymous" />
-            <link rel="dns-prefetch" href={new URL(process.env.NEXT_PUBLIC_API_BASE_URL).origin} />
-          </>
-        )}
-      </head>
-      <body className={`font-sans antialiased`}>
-        <Suspense fallback={<TranslationsFallback />}>
-          <NextIntlClientProvider messages={messages}>
-            <ErrorBoundary>
-              <AuthProvider>
-                <AuthGuard>
-                  <AppLayout>{children}</AppLayout>
-                </AuthGuard>
-                <WalletSetupModal />
-                <Analytics />
-              </AuthProvider>
-            </ErrorBoundary>
-          </NextIntlClientProvider>
-        </Suspense>
-      </body>
-    </html>
-  )
+    <Suspense fallback={<TranslationsFallback />}>
+      <NextIntlClientProvider messages={messages}>
+        <NavigationGuardProvider>
+          <AuthGuard>
+            {children}
+          </AuthGuard>
+        </NavigationGuardProvider>
+      </NextIntlClientProvider>
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Problem

Fixes #646.

`app/[locale]/layout.tsx` rendered a complete HTML document (`<html>`, `<head>`, `<body>`) which nested inside the root `app/layout.tsx` shell, producing invalid HTML with nested `<html>`, `<head>`, and `<body>` elements on every locale route. It also duplicated the full provider tree already present in the root layout.

## Fix

Stripped all HTML document structure and duplicated providers from `app/[locale]/layout.tsx`. It now only wraps children with locale-specific concerns:

- `NextIntlClientProvider` — loads locale messages for next-intl
- `NavigationGuardProvider` — navigation confirmation guard
- `AuthGuard` — redirects unauthenticated users

The root `app/layout.tsx` remains the single source of truth for the HTML shell, theme, global error handling, auth context, app chrome, and analytics.

## Changes

- `app/[locale]/layout.tsx` — removed `<html>`/`<head>`/`<body>`, duplicate `metadata`/`viewport` exports, and providers already in root layout (−67 lines, +15 lines)

## Testing

- Locale routes (e.g. `/en/dashboard`) render a single `<html>` element
- i18n translations, navigation guards, and auth redirects continue to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale-specific page handling by ensuring internationalization and authentication protections are consistently applied.
  * Reduced the risk of layout conflicts by separating shared application structure from locale-level content.
* **Improvements**
  * Enhanced navigation behavior within localized sections of the application.
  * Preserved loading support while locale messages and protected content are initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->