### PR TITLE
fix: replace raw <a> tags with Next.js <Link> in user-menu

### DIFF
--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 
 interface MenuItem {
@@ -70,10 +71,10 @@ export function UserMenu({ displayName }: UserMenuProps) {
           const Icon = item.icon;
           return (
             <DropdownMenuItem key={item.href} asChild>
-              <a href={item.href} className="cursor-pointer">
+              <Link href={item.href} className="cursor-pointer">
                 <Icon className="mr-2 h-4 w-4" />
                 <span>{item.title}</span>
-              </a>
+              </Link>
             </DropdownMenuItem>
           );
         })}
@@ -82,10 +83,10 @@ export function UserMenu({ displayName }: UserMenuProps) {
           const Icon = item.icon;
           return (
             <DropdownMenuItem key={item.href} asChild>
-              <a href={item.href} className="cursor-pointer">
+              <Link href={item.href} className="cursor-pointer">
                 <Icon className="mr-2 h-4 w-4" />
                 <span>{item.title}</span>
-              </a>
+              </Link>
             </DropdownMenuItem>
           );
         })}


### PR DESCRIPTION
## Summary
Fixes raw `<a>` tags in `components/user-menu.tsx` per issue #649.

## What changed
- Added `import Link from 'next/link'`
- Replaced `<a href={item.href}>` with `<Link href={item.href}>` 
  in both `menuItems` and `supportItems` map blocks (lines 73 and 85)

## Why
Raw `<a>` tags cause full-page reloads on every menu navigation, 
breaking SPA behavior and losing focus context. Next.js `<Link>` 
handles navigation client-side without a page reload.

## Files changed
- `components/user-menu.tsx`

Closes #649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior for links in the user menu and support menu.
  * Preserved the existing logout functionality and menu options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->