### PR TITLE
fix(auth): correct login auth argument mapping

### DIFF
--- a/contexts/__tests__/auth-context.test.tsx
+++ b/contexts/__tests__/auth-context.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider, useAuth } from "../auth-context";
+
+vi.mock("@/lib/api/user", () => ({
+  getMe: vi.fn().mockRejectedValue({ status: 401 }),
+}));
+
+function AuthHarness() {
+  const { userId, stellarAddress, isAuthenticated, login } = useAuth();
+
+  return (
+    <div>
+      <div data-testid="user-id">{userId ?? "null"}</div>
+      <div data-testid="stellar-address">{stellarAddress ?? "null"}</div>
+      <div data-testid="is-authenticated">{String(isAuthenticated)}</div>
+      <button type="button" onClick={() => login("user-1", "GABC123")}>
+        login
+      </button>
+    </div>
+  );
+}
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("stores the supplied user id and stellar address when login is called", async () => {
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+
+    expect(await screen.findByTestId("user-id")).toHaveTextContent("user-1");
+    expect(screen.getByTestId("stellar-address")).toHaveTextContent("GABC123");
+    expect(screen.getByTestId("is-authenticated")).toHaveTextContent("true");
+    expect(sessionStorage.getItem("acbu_user_id")).toBe("user-1");
+    expect(sessionStorage.getItem("acbu_stellar_address")).toBe("GABC123");
+  });
+});

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -1,13 +1,20 @@
-'use client';
+"use client";
 
-import React, { createContext, useCallback, useContext, useEffect, useState, useMemo } from 'react';
-import * as authApi from '@/lib/api/auth';
-import { onAuthError } from '@/lib/api/client';
-import { clearPasscode, clearTempPassphrase } from '@/lib/passcode-manager';
-import { logger } from '@/lib/logger';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useMemo,
+} from "react";
+import * as authApi from "@/lib/api/auth";
+import { onAuthError } from "@/lib/api/client";
+import { clearPasscode, clearTempPassphrase } from "@/lib/passcode-manager";
+import { logger } from "@/lib/logger";
 
-const USER_ID_KEY = 'acbu_user_id';
-const STELLAR_ADDRESS_KEY = 'acbu_stellar_address';
+const USER_ID_KEY = "acbu_user_id";
+const STELLAR_ADDRESS_KEY = "acbu_stellar_address";
 
 interface AuthState {
   userId: string | null;
@@ -33,8 +40,13 @@ interface AuthContextValue extends AuthState {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 function getStoredAuth(): AuthState {
-  if (typeof window === 'undefined') {
-    return { userId: null, stellarAddress: null, isAuthenticated: false, isHydrated: false };
+  if (typeof window === "undefined") {
+    return {
+      userId: null,
+      stellarAddress: null,
+      isAuthenticated: false,
+      isHydrated: false,
+    };
   }
   const userId = sessionStorage.getItem(USER_ID_KEY);
   const stellarAddress = sessionStorage.getItem(STELLAR_ADDRESS_KEY);
@@ -48,121 +60,126 @@ function getStoredAuth(): AuthState {
 }
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<AuthState>({ 
-    userId: null, 
-    stellarAddress: null, 
+  const [state, setState] = useState<AuthState>({
+    userId: null,
+    stellarAddress: null,
     isAuthenticated: false,
     isHydrated: false,
   });
-  const [sessionError, setSessionError] = useState('');
+  const [sessionError, setSessionError] = useState("");
 
   // Validate session on mount by checking if the httpOnly cookie is still valid
   const validateSession = useCallback(async () => {
-      const storedAuth = getStoredAuth();
-      
-      // If no userId in storage, definitely not authenticated
-      if (!storedAuth.userId) {
-        setSessionError('');
-        setState({ 
+    const storedAuth = getStoredAuth();
+
+    // If no userId in storage, definitely not authenticated
+    if (!storedAuth.userId) {
+      setSessionError("");
+      setState({
+        userId: null,
+        stellarAddress: null,
+        isAuthenticated: false,
+        isHydrated: true,
+      });
+      return;
+    }
+
+    // Validate the httpOnly cookie by making an API call
+    try {
+      setSessionError("");
+      const { getMe } = await import("@/lib/api/user");
+      await getMe(); // If this succeeds, the cookie is valid
+
+      // Cookie is valid, mark as authenticated
+      setState({
+        userId: storedAuth.userId,
+        stellarAddress: storedAuth.stellarAddress,
+        isAuthenticated: true,
+        isHydrated: true,
+      });
+    } catch (error) {
+      const status = (error as { status?: number })?.status;
+
+      if (status === 401) {
+        // Cookie is invalid or expired - clear stored auth
+        // The onAuthError handler will also be triggered
+        if (typeof window !== "undefined") {
+          sessionStorage.removeItem(USER_ID_KEY);
+          sessionStorage.removeItem(STELLAR_ADDRESS_KEY);
+        }
+        clearPasscode();
+        setSessionError("");
+        setState({
           userId: null,
           stellarAddress: null,
           isAuthenticated: false,
-          isHydrated: true 
+          isHydrated: true,
         });
-        return;
-      }
-
-      // Validate the httpOnly cookie by making an API call
-      try {
-        setSessionError('');
-        const { getMe } = await import('@/lib/api/user');
-        await getMe(); // If this succeeds, the cookie is valid
-        
-        // Cookie is valid, mark as authenticated
+      } else {
+        // Network error or other transient failure
+        // Keep stored data but mark as not authenticated until retry succeeds
+        setSessionError(
+          error instanceof Error ? error.message : "Failed to validate session",
+        );
         setState({
           userId: storedAuth.userId,
           stellarAddress: storedAuth.stellarAddress,
-          isAuthenticated: true,
+          isAuthenticated: false,
           isHydrated: true,
         });
-      } catch (error) {
-        const status = (error as { status?: number })?.status;
-        
-        if (status === 401) {
-          // Cookie is invalid or expired - clear stored auth
-          // The onAuthError handler will also be triggered
-          if (typeof window !== 'undefined') {
-            sessionStorage.removeItem(USER_ID_KEY);
-            sessionStorage.removeItem(STELLAR_ADDRESS_KEY);
-          }
-          clearPasscode();
-          setSessionError('');
-          setState({
-            userId: null,
-            stellarAddress: null,
-            isAuthenticated: false,
-            isHydrated: true,
-          });
-        } else {
-          // Network error or other transient failure
-          // Keep stored data but mark as not authenticated until retry succeeds
-          setSessionError(error instanceof Error ? error.message : 'Failed to validate session');
-          setState({
-            userId: storedAuth.userId,
-            stellarAddress: storedAuth.stellarAddress,
-            isAuthenticated: false,
-            isHydrated: true,
-          });
-        }
       }
-    }, []);
+    }
+  }, []);
 
   useEffect(() => {
     void validateSession();
   }, [validateSession]);
 
-  const setAuth = useCallback((userId: string | null, stellarAddress: string | null = null) => {
-    if (typeof window !== 'undefined') {
-      if (userId) {
-        sessionStorage.setItem(USER_ID_KEY, userId);
-        if (stellarAddress) {
-          sessionStorage.setItem(STELLAR_ADDRESS_KEY, stellarAddress);
+  const setAuth = useCallback(
+    (userId: string | null, stellarAddress: string | null = null) => {
+      if (typeof window !== "undefined") {
+        if (userId) {
+          sessionStorage.setItem(USER_ID_KEY, userId);
+          if (stellarAddress) {
+            sessionStorage.setItem(STELLAR_ADDRESS_KEY, stellarAddress);
+          } else {
+            sessionStorage.removeItem(STELLAR_ADDRESS_KEY);
+          }
         } else {
+          sessionStorage.removeItem(USER_ID_KEY);
           sessionStorage.removeItem(STELLAR_ADDRESS_KEY);
         }
-      } else {
-        sessionStorage.removeItem(USER_ID_KEY);
-        sessionStorage.removeItem(STELLAR_ADDRESS_KEY);
       }
-    }
 
-    setState({
-      userId,
-      stellarAddress,
-      isAuthenticated: !!userId,
-      isHydrated: true,
-    });
-  }, []);
+      setState({
+        userId,
+        stellarAddress,
+        isAuthenticated: !!userId,
+        isHydrated: true,
+      });
+    },
+    [],
+  );
 
   const refreshStellarAddress = useCallback(async () => {
     if (!state.isAuthenticated) return;
     try {
-      const { getBalance } = await import('@/lib/api/user');
+      const { getBalance } = await import("@/lib/api/user");
       const balance = await getBalance();
-      
+
       if (balance.stellar_address) {
         setAuth(state.userId, balance.stellar_address);
       }
     } catch (e) {
-      logger.error('Failed to refresh stellar address', e);
+      logger.error("Failed to refresh stellar address", e);
     }
   }, [state.isAuthenticated, state.userId, setAuth]);
 
   const login = useCallback(
     (userId: string, stellarAddress: string | null = null) => {
-      setAuth(null, userId, stellarAddress);
+      setAuth(userId, stellarAddress);
     },
-    [setAuth]
+    [setAuth],
   );
 
   const logout = useCallback(async () => {
@@ -193,7 +210,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       sessionError,
       refetchSession: validateSession,
     }),
-    [state, login, logout, setAuth, refreshStellarAddress, sessionError, validateSession]
+    [
+      state,
+      login,
+      logout,
+      setAuth,
+      refreshStellarAddress,
+      sessionError,
+      validateSession,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
@@ -202,7 +227,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 export function useAuth() {
   const ctx = useContext(AuthContext);
   if (!ctx) {
-    throw new Error('useAuth must be used within AuthProvider');
+    throw new Error("useAuth must be used within AuthProvider");
   }
   return ctx;
 }


### PR DESCRIPTION
## Summary
- Fix the login flow in the auth context so it passes the correct arguments to `setAuth`.
- Preserve the real stellar address instead of accidentally treating the user ID as the address.
- Add a regression test covering the login path and auth storage behavior.

## Testing
- Verified with `pnpm exec vitest run contexts/__tests__/auth-context.test.tsx`

Closes #636 