### PR TITLE
fix: replace undefined passcodeHolder with inMemoryPasscode in passco…

### DIFF
--- a/lib/passcode-manager.ts
+++ b/lib/passcode-manager.ts
@@ -17,14 +17,14 @@ let inMemoryTempPassphrase: string | null = null;
  * though active XSS can still access it while in memory.
  */
 export function setPasscode(passcode: string): void {
-  passcodeHolder.set(passcode);
+  inMemoryPasscode = passcode;
 }
 
 /**
  * Get the stored passcode from memory.
  */
 export function getPasscode(): string | null {
-  return passcodeHolder.get();
+  return inMemoryPasscode;
 }
 
 /**
@@ -32,14 +32,14 @@ export function getPasscode(): string | null {
  * Called on logout or when user explicitly clears it.
  */
 export function clearPasscode(): void {
-  passcodeHolder.clear();
+  inMemoryPasscode = null;
 }
 
 /**
  * Check if passcode is available in memory.
  */
 export function hasPasscode(): boolean {
-  return passcodeHolder.has();
+  return inMemoryPasscode !== null;
 }
 
 /**


### PR DESCRIPTION
 fix: resolve undefined passcodeHolder bug in passcode-manager
  
  The four exported functions setPasscode, getPasscode, clearPasscode, and hasPasscode all
  referenced a passcodeHolder object that was never defined, causing a ReferenceError at runtime
  on any call. This silently broke all wallet operations that depend on passcode state —
  including encrypting and decrypting wallet secrets stored in IndexedDB.
  
  Changes:
  
  - Replaced passcodeHolder.set/get/clear/has() calls with direct reads and writes to
  inMemoryPasscode, the module-level variable that was already declared for this purpose.
  - No behavior change — the in-memory, non-persistent storage model is preserved.
  
  Impact:
  
  - setPasscode, getPasscode, clearPasscode, hasPasscode now work correctly.
  - wallet-storage.ts and any other consumers that call these functions will no longer throw on
  passcode operations.
  - The XSS mitigation design (passcode in memory only, never written to
  sessionStorage/localStorage) is unchanged.
closes #701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved passcode handling by simplifying how passcodes are temporarily stored and retrieved.
  * Existing passcode management behavior and interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->