### PR TITLE
fix(use-balance): remove deprecated refresh alias, migrate consumers …

### DIFF
--- a/app/mint/mint.test.tsx
+++ b/app/mint/mint.test.tsx
@@ -97,7 +97,7 @@ describe('MintPage', () => {
       balance: 100,
       balanceSource: 'stellar',
       loading: false,
-      refresh: vi.fn(),
+      refetch: vi.fn(),
       error: '',
     })
 

--- a/app/mint/page.tsx
+++ b/app/mint/page.tsx
@@ -309,7 +309,7 @@ export default function MintPage() {
   const opts = useApiOpts();
   const router = useRouter();
   const { userId, stellarAddress } = useAuth();
-  const { balance, balanceSource, loading: balanceLoading, refresh: refreshBalance } = useBalance();
+  const { balance, balanceSource, loading: balanceLoading, refetch: refetchBalance } = useBalance();
   const kit = useStellarWalletsKit();
   const { uiError: mintUiError, setApiError: setMintApiError, clearError: clearMintError, isSubmitDisabled: isMintDisabled } = useApiError();
   const { uiError: burnUiError, setApiError: setBurnApiError, clearError: clearBurnError, isSubmitDisabled: isBurnDisabled } = useApiError();
@@ -515,7 +515,7 @@ export default function MintPage() {
             setMintAcbuReceived(
                 typeof acbu === "number" && Number.isFinite(acbu) ? acbu : null,
             );
-            refreshBalance();
+            refetchBalance();
             refetchFiatAccounts();
             setStep("success");
         } catch (e) {

--- a/app/send/send.test.tsx
+++ b/app/send/send.test.tsx
@@ -88,7 +88,7 @@ describe('SendPage', () => {
     vi.mocked(useBalanceHook.useBalance).mockReturnValue({
       balance: 100,
       loading: false,
-      refresh: vi.fn(),
+      refetch: vi.fn(),
       error: '',
     })
 

--- a/hooks/use-balance.ts
+++ b/hooks/use-balance.ts
@@ -10,13 +10,8 @@ interface UseBalanceReturn {
   balanceSource?: string;
   loading: boolean;
   error: string;
-  /**
-   * Triggers a re-fetch of the balance.
-   * `refetch` is preferred in UI; `refresh` kept for backwards-compat.
-   */
+  /** Triggers a re-fetch of the balance. */
   refetch: () => void;
-  /** @deprecated Prefer `refetch()` */
-  refresh: () => void;
 }
 
 /**
@@ -32,7 +27,6 @@ export function useBalance(): UseBalanceReturn {
   const [tick, setTick] = useState(0);
 
   const refetch = useCallback(() => setTick((t) => t + 1), []);
-  const refresh = refetch;
 
   // Auto-refresh balance every 30 seconds to catch external transactions.
   // No stale closure risk: `interval` is captured in the same effect scope, so
@@ -87,5 +81,5 @@ export function useBalance(): UseBalanceReturn {
     };
   }, [opts.token, tick]);
 
-  return { balance, balanceSource, loading, error, refetch, refresh };
+  return { balance, balanceSource, loading, error, refetch };
 }


### PR DESCRIPTION
…to refetch

Closes #692

- Remove the deprecated `refresh` alias from `UseBalanceReturn` interface and from the hook's return value. The alias was added for backwards-compat but caused confusion: callers that destructured `refresh: refreshBalance` silently received the function while the canonical name was `refetch`.

- Migrate the only consumer using the old name: app/mint/page.tsx: `refresh: refreshBalance` -> `refetch: refetchBalance` and update the call-site `refreshBalance()` -> `refetchBalance()`.

- Update test mocks in mint.test.tsx and send.test.tsx to reflect the updated interface (replace `refresh: vi.fn()` with `refetch: vi.fn()`).

All other consumers (app/[locale]/page.tsx, app/currency/page.tsx, app/send/page.tsx, app/me/page.tsx) already used `refetch` and require no changes.

Note: app/mint/page.tsx has pre-existing lint errors (duplicate variable declarations, unused variables) that are unrelated to this change and tracked separately.

## Description

<!-- What does this PR do? Provide a clear summary of the changes. -->

## Why

<!-- Why is this change needed? Link related issues with "Closes #123" or "Fixes #456". -->

## How to test

<!-- Step-by-step instructions so reviewers can verify the change locally. -->

1. 
2. 
3. 

## Screenshots / Recordings

<!-- Attach before/after screenshots or screen recordings for UI changes. Delete this section if not applicable. -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] Added or updated tests (if applicable)
- [ ] No new TypeScript or lint errors (`pnpm typecheck && pnpm lint`)
- [ ] Tested on mobile viewport (if UI change)
- [ ] Accessibility checked (keyboard navigation, screen reader)
Closes #692 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated balance refreshing after mint completion so the displayed ACBU balance reloads correctly.
  * Improved consistency when reloading balance information across minting and sending flows.

* **Refactor**
  * Standardized balance updates around a single refresh action, removing the deprecated alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->