### PR TITLE
Fix issues #634, #644, #650, #652

### DIFF
--- a/app/[locale]/auth/wallet-setup/page.tsx
+++ b/app/[locale]/auth/wallet-setup/page.tsx
@@ -96,7 +96,9 @@ export default function WalletSetupPage() {
     try {
       await userApi.postWalletConfirm({ wallet_address: publicKey });
     } catch (err) {
-      console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+      if (process.env.NODE_ENV === 'development') {
+        console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+      }
       // Don't throw - the address is set, confirmation can retry later if needed
     }
   };
@@ -191,7 +193,9 @@ export default function WalletSetupPage() {
             try {
               await userApi.postWalletConfirm({ wallet_address: pubKey });
             } catch (err) {
-              console.warn("Wallet confirm failed, but wallet address was set.", err);
+              if (process.env.NODE_ENV === 'development') {
+                console.warn("Wallet confirm failed, but wallet address was set.", err);
+              }
             }
 
             setSuccess("Wallet connected successfully!");

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -84,7 +84,9 @@ export default function WalletPage() {
       try {
         await userApi.postWalletConfirm({ wallet_address: newAddress }, opts);
       } catch (err) {
-        console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+        if (process.env.NODE_ENV === 'development') {
+          console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+        }
       }
 
       handleFinish("New wallet created successfully!");
@@ -133,7 +135,9 @@ export default function WalletPage() {
       try {
         await userApi.postWalletConfirm({ wallet_address: newAddress }, opts);
       } catch (err) {
-        console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+        if (process.env.NODE_ENV === 'development') {
+          console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+        }
       }
 
       handleFinish("Wallet imported successfully!");
@@ -171,7 +175,9 @@ export default function WalletPage() {
             try {
               await userApi.postWalletConfirm({ wallet_address: pubKey }, opts);
             } catch (err) {
-              console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+              if (process.env.NODE_ENV === 'development') {
+                console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+              }
             }
 
             handleFinish("External wallet connected successfully!");

--- a/components/wallet-setup-modal.tsx
+++ b/components/wallet-setup-modal.tsx
@@ -105,7 +105,9 @@ export function WalletSetupModal() {
     try {
       await userApi.postWalletConfirm({ wallet_address: publicKey });
     } catch (err) {
-      console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+      if (process.env.NODE_ENV === 'development') {
+        console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+      }
       // Don't throw - the address is set, confirmation can retry later if needed
     }
   };
@@ -174,7 +176,9 @@ export function WalletSetupModal() {
             try {
               await userApi.postWalletConfirm({ wallet_address: pubKey });
             } catch (err) {
-              console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+              if (process.env.NODE_ENV === 'development') {
+                console.warn("Wallet confirm failed, but wallet address was set. User can continue.", err);
+              }
             }
 
             handleFinish();


### PR DESCRIPTION
Fixes #634, #644, #650, #652

## What changed
- Wrapped all console.warn calls in development-only guards using `process.env.NODE_ENV === 'development'`
- This prevents debug messages from appearing in production browser console

## Why
- console.warn logs to production browser console, which is unnecessary for non-critical wallet confirmation errors
- Reduces noise in end-user browser console while retaining debug logging for developers

## How to test
- In production build, verify console.warn messages don't appear when wallet confirmation fails
- In development build, verify console.warn messages still appear for debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning messages in production when wallet confirmation encounters an error.
  * Wallet setup continues as expected after confirmation failures, while diagnostic warnings remain available during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->