### PR TITLE
Fix issues #634, #644, #650, #652 - Stellar Wave bugs

### DIFF
--- a/app/[locale]/activity/page.tsx
+++ b/app/[locale]/activity/page.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Activity | ACBU',
-  description: 'View your complete transaction history including mints, burns, and transfers on the ACBU platform.',
-};
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo } from 'react';
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Dashboard | ACBU',
-  description: 'View your ACBU wallet balance, recent transactions, and access key features like sending money, minting tokens, and managing savings.',
-};
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { useTranslations, useFormatter } from 'next-intl';

--- a/app/admin/users/[id]/page.tsx
+++ b/app/admin/users/[id]/page.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import type { Metadata } from 'next';
 import { useReducer } from 'react';
 import { useParams } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Edit User | ACBU Admin',
-  description: 'Edit user account details in the ACBU admin dashboard.',
-};
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/app/bills/catalog/page.tsx
+++ b/app/bills/catalog/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Bill Catalog | ACBU',
-  description: 'Browse available bill payment services and providers on the ACBU platform.',
-};
 
 import React from 'react';
 import Link from 'next/link';

--- a/app/bills/pay/page.tsx
+++ b/app/bills/pay/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Pay Bill | ACBU',
-  description: 'Complete your bill payment transaction using ACBU tokens.',
-};
 
 import React from 'react';
 import Link from 'next/link';

--- a/app/business/page.tsx
+++ b/app/business/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Business Services | ACBU',
-  description: 'Explore ACBU business solutions including merchant services, payroll, and enterprise payment solutions.',
-};
 
 import React, { useEffect, useState } from 'react';
 import { PageContainer } from '@/components/layout/page-container';

--- a/app/business/sme/page.tsx
+++ b/app/business/sme/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'SME Services | ACBU',
-  description: 'Explore ACBU services for small and medium enterprises including business accounts and payment solutions.',
-};
 
 import React from 'react';
 import Link from 'next/link';

--- a/app/lending/admin/page.tsx
+++ b/app/lending/admin/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Lending Admin | ACBU',
-  description: 'Manage and review loan applications, approve or reject requests, and monitor lending operations.',
-};
 
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';

--- a/app/lending/page.tsx
+++ b/app/lending/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Lending | ACBU',
-  description: 'Apply for loans and access credit facilities using your ACBU tokens as collateral.',
-};
 
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';

--- a/app/me/activity/page.tsx
+++ b/app/me/activity/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'My Activity | ACBU',
-  description: 'View your personal transaction history and account activity on ACBU.',
-};
 
 import React from 'react';
 import { useRouter } from 'next/navigation';

--- a/app/me/kyc/[id]/page.tsx
+++ b/app/me/kyc/[id]/page.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import type { Metadata } from 'next';
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'KYC Application | ACBU',
-  description: 'View and manage your KYC verification application status.',
-};
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';

--- a/app/me/kyc/page.tsx
+++ b/app/me/kyc/page.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import type { Metadata } from 'next';
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'KYC Verification | ACBU',
-  description: 'Complete your KYC verification to unlock full ACBU account features and higher limits.',
-};
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';

--- a/app/me/kyc/start/page.tsx
+++ b/app/me/kyc/start/page.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import type { Metadata } from 'next';
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Start KYC | ACBU',
-  description: 'Start your KYC verification process for your ACBU account.',
-};
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';

--- a/app/me/kyc/upload/page.tsx
+++ b/app/me/kyc/upload/page.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import type { Metadata } from 'next';
 import React, { useState, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Upload KYC Documents | ACBU',
-  description: 'Upload your identity verification documents for KYC processing.',
-};
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
 import { Card } from '@/components/ui/card';

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import type { Metadata } from 'next';
 import React, { useState, useEffect, useRef } from 'react';
 import { PageContainer } from '@/components/layout/page-container';
 
-export const metadata: Metadata = {
-  title: 'My Account | ACBU',
-  description: 'Manage your ACBU account, profile, and settings.',
-};
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useRouter } from 'next/navigation';

--- a/app/me/settings/contacts/page.tsx
+++ b/app/me/settings/contacts/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Contacts | ACBU',
-  description: 'Manage your ACBU contacts for quick and easy money transfers to frequently used recipients.',
-};
 
 import React, { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';

--- a/app/me/settings/guardians/page.tsx
+++ b/app/me/settings/guardians/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Guardians | ACBU',
-  description: 'Manage your account guardians who can help you recover access to your ACBU account if needed.',
-};
 
 import React, { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';

--- a/app/me/settings/page.tsx
+++ b/app/me/settings/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Settings | ACBU',
-  description: 'Manage your ACBU account settings including security, wallet, contacts, and guardians.',
-};
 
 import React from 'react';
 import { useRouter } from 'next/navigation';

--- a/app/me/settings/receive/page.tsx
+++ b/app/me/settings/receive/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Receive Money | ACBU',
-  description: 'View your ACBU payment address and QR code to receive money from other users.',
-};
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';

--- a/app/me/settings/security/page.tsx
+++ b/app/me/settings/security/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Security Settings | ACBU',
-  description: 'Manage your ACBU security settings including two-factor authentication, active sessions, and security preferences.',
-};
 
 import React, { useMemo, useState } from 'react';
 import { plural } from '@/lib/plural';

--- a/app/reserves/page.tsx
+++ b/app/reserves/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
-  title: 'Reserves | ACBU',
-  description: 'View ACBU reserve holdings and transparency reports. Monitor the backing assets that support ACBU tokens.',
-};
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { Metadata } from 'next';
 import React, { useState, useEffect, useDeferredValue } from 'react';
 import Link from 'next/link';
 import { PageContainer } from '@/components/layout/page-container';
@@ -8,10 +7,6 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { SkeletonList } from '@/components/ui/skeleton-list';
 
-export const metadata: Metadata = {
-  title: 'Transactions | ACBU',
-  description: 'View your ACBU transaction history, including transfers, mints, and burns.',
-};
 import { EmptyState } from '@/components/ui/empty-state';
 import { ArrowLeft, Clock } from 'lucide-react';
 import { useApiOpts } from '@/hooks/use-api';


### PR DESCRIPTION
Closes #634, Closes #644, Closes #650, Closes #652

## Issues Resolved

**#634 - lib/api/client.ts truncated**: Verified file is complete with all required exports (get, post, patch, put, del functions present at lines 158-176)

**#644 - Metadata in use client components**: Removed 'export const metadata' from 22 use client pages. Metadata exports are silently ignored by Next.js App Router in client components and don't generate page titles/descriptions.

**#650 - Duplicate disabled props**: Verified this issue was already resolved in main branch history. No duplicate props currently exist.

**#652 - console.warn in production**: Verified this issue was already resolved in main branch. console.warn calls have been replaced with logger.warn which handles production/development appropriately.

## Changes
- Removed metadata exports from 22 use client page components
- Removed unused Metadata type imports from these pages  
- Metadata is properly handled in layout components (Server Components)
- Fixes Next.js App Router console warnings about invalid metadata usage

## Affected Files (22 total)
app/[locale]/page.tsx, app/[locale]/activity/page.tsx, app/business/page.tsx, app/business/sme/page.tsx, app/lending/page.tsx, app/lending/admin/page.tsx, app/transactions/page.tsx, app/me/page.tsx, app/me/activity/page.tsx, app/me/kyc/page.tsx, app/me/kyc/start/page.tsx, app/me/kyc/[id]/page.tsx, app/me/kyc/upload/page.tsx, app/me/settings/page.tsx, app/me/settings/security/page.tsx, app/me/settings/contacts/page.tsx, app/me/settings/receive/page.tsx, app/me/settings/guardians/page.tsx, app/reserves/page.tsx, app/bills/catalog/page.tsx, app/bills/pay/page.tsx, app/admin/users/[id]/page.tsx

## Testing
- Next.js should no longer warn about metadata in client components
- Page titles/descriptions should still work via layout.tsx Server Components
- All page functionality remains unchanged