### PR TITLE
fix: replace 'as any' casts with proper BufferSource types in wallet-…

### DIFF
--- a/lib/wallet-storage.ts
+++ b/lib/wallet-storage.ts
@@ -58,7 +58,7 @@ async function deriveKey(passcode: string, salt: Uint8Array): Promise<CryptoKey>
   return crypto.subtle.deriveKey(
     {
       name: 'PBKDF2',
-      salt: salt as any,
+      salt: salt as BufferSource,
       iterations: PBKDF2_ITERATIONS,
       hash: 'SHA-256',
     },
@@ -105,9 +105,9 @@ async function decryptSecret(encrypted: string, passcode: string): Promise<strin
     const ciphertext = fromBase64(payload.ciphertext);
     const key = await deriveKey(passcode, salt);
     const decrypted = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv: iv as any },
+      { name: 'AES-GCM', iv: iv as BufferSource },
       key,
-      ciphertext as any,
+      ciphertext as BufferSource,
     );
     return textDecoder.decode(decrypted);
   } catch {


### PR DESCRIPTION

Replaces unsafe `as any` type casts with proper `BufferSource` types in `lib/wallet-storage.ts` for Web Crypto API parameters (salt, iv, ciphertext). Improves type safety with no runtime changes.

Closes #699 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with WebCrypto encryption and decryption operations.
  * Strengthened type handling for encryption salts, initialization vectors, and encrypted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->