### PR TITLE
debouncedAccount computed twice fixed

### DIFF
--- a/app/send/page.tsx
+++ b/app/send/page.tsx
@@ -214,37 +214,6 @@ export default function SendPage() {
 
   useScrollRestoration('/send', !loadingTransfers);
 
-  const handleSendDialogChange = useCallback((open: boolean) => setShowSendDialog(open), []);
-  const handleConfirmDialogChange = useCallback(
-    (open: boolean) => {
-      if (!open && !sending) setConfirmedAmount("");
-      setShowConfirmDialog(open);
-    },
-    [sending],
-  );
-  const handleSuccessDialogChange = useCallback((open: boolean) => setShowSuccessDialog(open), []);
-  const handleUseContactChange = useCallback((v: string) => setUseContact(v === "contact"), []);
-  const handleContactSelect = useCallback(
-    (id: string) => {
-      const c = contacts.find((x: ContactItem) => x.id === id);
-      if (c) setSelectedContact(c);
-    },
-    [contacts],
-  );
-  const handleCustomRecipientChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setCustomRecipient(e.target.value),
-    [],
-  );
-  const handleAmountChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const v = e.target.value;
-    if (v === "" || /^\d*\.?\d*$/.test(v)) setAmount(v);
-  }, []);
-  const debouncedAmount = useDebounce(amount, 300);
-  const handleNoteChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setNote(e.target.value),
-    [],
-  );
-
   const getToValue = useCallback(
     () =>
       useContact && selectedContact


### PR DESCRIPTION
I’m turning your issue report into a concise PR description and will fill in the sections with the change we made and the verification status.

Here is a ready-to-paste PR description:

## Description

This PR removes a duplicated block in page.tsx where the amount-change handlers and the `debouncedAmount` logic were defined twice. The component now uses a single active implementation, which removes the dead duplicate code and makes the send-page logic clearer.

## Why

Closes #700

## How to test

1. Open the send page and enter an amount in the amount field.
2. Confirm the form validation and send/continue actions still behave as expected.
3. Review the component to ensure only one amount handler/debounce path remains.

## Screenshots / Recordings

N/A

## Checklist

- [x] Self-reviewed the diff
- [ ] Added or updated tests (if applicable)
- [ ] No new TypeScript or lint errors (`pnpm typecheck && pnpm lint`)
- [ ] Tested on mobile viewport (if UI change)
- [ ] Accessibility checked (keyboard navigation, screen reader)

> Note: editor diagnostics for page.tsx reported no errors, but the full lint/typecheck command was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer confirmation behavior by clearing stale confirmation amounts when the dialog closes.
  * Enhanced scroll restoration during the send flow, particularly after transfers finish loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->