### PR TITLE
Feat: Inline script renders without guaranteed nonce

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -114,22 +114,24 @@ export default async function RootLayout({
         <link rel="stylesheet" href="/print.css" media="print" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-        <script
-          nonce={nonce}
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                try {
-                  const mql = window.matchMedia('(prefers-color-scheme: dark)');
-                  function updateTheme(e) {
-                    document.documentElement.classList.toggle('dark', e.matches);
-                  }
-                  mql.addEventListener('change', updateTheme);
-                } catch (err) {}
-              })();
-            `,
-          }}
-        />
+        {nonce && (
+          <script
+            nonce={nonce}
+            dangerouslySetInnerHTML={{
+              __html: `
+                (function() {
+                  try {
+                    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+                    function updateTheme(e) {
+                      document.documentElement.classList.toggle('dark', e.matches);
+                    }
+                    mql.addEventListener('change', updateTheme);
+                  } catch (err) {}
+                })();
+              `,
+            }}
+          />
+        )}
       </head>
       <body className={`font-sans antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>


### PR DESCRIPTION
## Summary

closes #653

- Fixed issue #653 in `app/layout.tsx`.
- Inline dark-mode script now renders only when a valid CSP nonce is available.
- Prevents unauthorized inline scripts under the strict CSP policy.
- Preserved the nonce on the `<script>` element.
- `git diff --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme handling under strict Content Security Policies by rendering the theme-setting script only when properly authorized.
  * Prevented unauthorized or invalid inline scripts from being emitted when a security nonce is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->