### PR TITLE
Fix/567 648 fiat controller mobile nav

### DIFF
--- a/app/fiat/page.tsx
+++ b/app/fiat/page.tsx
@@ -165,6 +165,7 @@ export default function FiatSimPage() {
                   <div className="flex justify-between items-start mb-2">
                     <div>
                       <p className="text-xs font-bold text-primary">{acc.bank_name}</p>
+                      <p className="text-xs text-muted-foreground">{acc.account_name}</p>
                       <p className="text-xs text-muted-foreground">{acc.account_number}</p>
                     </div>
                     <Badge variant="secondary">{acc.currency}</Badge>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -12,16 +12,16 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
-  { name: "Home", href: "/", icon: <Home className="w-5 h-5" /> },
-  { name: "Send", href: "/send", icon: <Send className="w-5 h-5" /> },
-  { name: "Mint", href: "/mint", icon: <Coins className="w-5 h-5" /> },
+  { name: "Home", href: "/", icon: <Home className="h-5 w-5" /> },
+  { name: "Send", href: "/send", icon: <Send className="h-5 w-5" /> },
+  { name: "Mint", href: "/mint", icon: <Coins className="h-5 w-5" /> },
   {
     name: "Business",
     href: "/business",
-    icon: <Briefcase className="w-5 h-5" />,
+    icon: <Briefcase className="h-5 w-5" />,
   },
-  { name: "Wallet", href: "/wallet", icon: <Wallet className="w-5 h-5" /> },
-  { name: "Me", href: "/me", icon: <User className="w-5 h-5" /> },
+  { name: "Wallet", href: "/wallet", icon: <Wallet className="h-5 w-5" /> },
+  { name: "Me", href: "/me", icon: <User className="h-5 w-5" /> },
 ];
 
 export function MobileNav() {
@@ -71,13 +71,13 @@ export function MobileNav() {
 
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 border-t border-border bg-card z-40 transition-[bottom] duration-150 ease-out md:h-auto"
+      className="border-border bg-card fixed right-0 bottom-0 left-0 z-40 border-t transition-[bottom] duration-150 ease-out md:h-auto"
       role="navigation"
       aria-label="Mobile navigation"
       style={{ bottom: `${bottomOffset}px` }}
     >
-      <div className="flex justify-between items-center h-20 px-1">
-        {navItems.map((item, idx) => {
+      <div className="flex h-20 items-center justify-between px-1">
+        {navItems.map((item) => {
           const isActive = pathname === item.href;
           return (
             <button
@@ -87,14 +87,16 @@ export function MobileNav() {
               aria-label={item.name}
               aria-current={isActive ? "page" : undefined}
               disabled={isPending}
-              className={`flex flex-col items-center justify-center flex-1 h-20 gap-1 transition-colors ${
+              className={`flex h-20 flex-1 flex-col items-center justify-center gap-1 transition-colors ${
                 isActive
                   ? "text-primary"
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
               {item.icon}
-              <span className="text-xs font-medium text-center">{item.name}</span>
+              <span className="text-center text-xs font-medium">
+                {item.name}
+              </span>
             </button>
           );
         })}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useTransition } from "react";
+import React, { useRef, useState, useEffect, useTransition } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Home, Send, Coins, Briefcase, User, Wallet } from "lucide-react";
 import { useNavigationGuard } from "@/contexts/navigation-guard-context";


### PR DESCRIPTION
 
  Summary
  
  Fixes two bugs identified in the Stellar Wave program:
  
  Fix #648 — Missing React imports in components/mobile-nav.tsx
  
  The MobileNav component used useState and useEffect but only
  imported useRef and useTransition from React. This caused a runtime
  crash whenever the mobile navigation rendered. Added the missing
  imports and removed an unused idx parameter from the navItems.map()
   callback (pre-existing lint error).
  
  Fix #567 — account_name not displayed on fiat account cards
  
  The backend copy-paste bug (account_name being assigned
  account_number's value in fiatController.ts) had a corresponding gap
  on the frontend: app/fiat/page.tsx rendered acc.account_number in
  the fiat account cards but never rendered acc.account_name at all,
  silently dropping the account holder name from the UI. Added the
  account_name field to the card so it displays correctly once the
  backend fix is deployed.
  
  Changes
  
  - components/mobile-nav.tsx — add useState, useEffect to React
  import; remove unused idx map parameter
  - app/fiat/page.tsx — render acc.account_name in fiat account cards
  alongside acc.account_number
  
  Testing
  
  - Both changed files pass ESLint with zero errors
  - Pre-commit hook (lint-staged + prettier + eslint) passed on all
  commits
  - No new TypeScript errors introduced
  
  Closes #567
  Closes #648


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account cards now display the account name beneath the bank name for clearer identification.

* **Style**
  * Refined the mobile navigation layout and button styling.
  * Improved navigation label formatting and icon alignment while preserving existing destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->