### PR TITLE
fix: enable AuthGuard in root layout (#773, #771)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { I18nProvider } from '@/contexts/i18n-context'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { GlobalErrorHandler } from '@/components/global-error-handler'
 import './globals.css'
+import { AuthGuard } from '@/components/layout/auth-guard';
 import { AppLayout } from '@/components/app-layout';
 import { WalletSetupModal } from '@/components/wallet-setup-modal';
 import { Toaster } from '@/components/ui/toaster';
@@ -140,7 +141,7 @@ export default async function RootLayout({
           <ErrorBoundary level="app">
             <I18nProvider>
               <AuthProvider>
-                <AppLayout>{children}</AppLayout>
+                <AppLayout><AuthGuard>{children}</AuthGuard></AppLayout>
                 <WalletSetupModal />
                 <Toaster />
                 {/*


### PR DESCRIPTION
## Summary

- **#773 (Critical):** Imported AuthGuard in pp/layout.tsx and wrapped children with it inside <AppLayout>. Protected routes now redirect to /auth/signin when unauthenticated.
- **#771 (Low):** Unused ArrowRight import in pp/business/sme/page.tsx was already removed on dev.

## Changes

### pp/layout.tsx
- Added import { AuthGuard } from '@/components/layout/auth-guard'
- Changed <AppLayout>{children}</AppLayout> → <AppLayout><AuthGuard>{children}</AuthGuard></AppLayout>

## Acceptance Criteria
- ✅ Protected routes redirect to sign-in when unauthenticated (AuthGuard wraps all children)
- ✅ Lint clean (ArrowRight already removed from SME page on dev)

Closes #773
Closes #771