### PR TITLE
Clean up savings wiring and KYC badge usage

### DIFF
--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -79,9 +79,9 @@ function LocalKycBadge({ status, loading }: { status: KycStatus | undefined | nu
   if (loading) {
     return <div className="h-5 w-24 rounded-full bg-muted animate-pulse" />;
   }
-  const { label, className, Icon } = getKycBadgeConfig(status);
+  const { label, variant, className, Icon } = getKycBadgeConfig(status);
   return (
-    <Badge variant="outline" className={`text-xs font-medium gap-1 px-2 py-0.5 ${className}`}>
+    <Badge variant={variant} className={`text-xs font-medium gap-1 px-2 py-0.5 ${className}`}>
       <Icon className="w-3 h-3 flex-shrink-0" />
       {label}
     </Badge>

--- a/app/savings/page.tsx
+++ b/app/savings/page.tsx
@@ -16,49 +16,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ArrowLeft, PiggyBank, TrendingUp, Plus, AlertCircle } from "lucide-react";
-import type { LucideIcon } from 'lucide-react';
 import { PageContainer } from "@/components/layout/page-container";
 import { useApiOpts } from "@/hooks/use-api";
 import * as userApi from "@/lib/api/user";
 import * as savingsApi from "@/lib/api/savings";
-import { resolveRecipient } from "@/lib/api/recipient";
 import { formatAmount } from "@/lib/utils";
 import { BalanceSkeleton } from "@/components/ui/balance-skeleton";
-
-/**
- * Resolve any user identifier (Stellar address, phone, alias, pay URI)
- * through the backend recipient resolver to obtain the canonical pay_uri.
- * Falls back to the raw value when the resolver is unavailable so that
- * Stellar-format addresses still work offline.
- */
-async function resolveUserUri(
-  raw: string,
-  opts: Parameters<typeof resolveRecipient>[1],
-): Promise<string> {
-  try {
-    const resolved = await resolveRecipient(raw, opts);
-    if (resolved.pay_uri) return resolved.pay_uri;
-    if (resolved.alias) return resolved.alias;
-  } catch {
-    // Resolver unavailable — fall through to raw value.
-  }
-  return raw;
-}
-
-interface SavingsAccount {
-    id: string;
-    name: string;
-    apy: number;
-    balance: number;
-    icon: LucideIcon;
-    description: string;
-    color: string;
-}
-
-
-const SAVINGS_ACCOUNT_TYPES: Array<{ id: string; name: string; apy: number; balance: number; icon: LucideIcon; description: string; color: string }> = [
-  { id: "high-yield", name: "High-Yield Savings", apy: 8, balance: 0, icon: PiggyBank, description: "Earn 8% APY on your savings", color: "text-green-600" },
-];
 
 interface SavingsGoal {
   id: string;
@@ -97,10 +60,6 @@ export default function SavingsPage() {
   const [receiveError, setReceiveError] = useState("");
   const [goals, setGoals] = useState<SavingsGoal[]>(initialGoals);
 
-  const [selectedAccount, setSelectedAccount] = useState<(typeof SAVINGS_ACCOUNT_TYPES)[0] | null>(null);
-  const [showDialog, setShowDialog] = useState(false);
-  const [showDepositDialog, setShowDepositDialog] = useState(false);
-  const [depositAmount, setDepositAmount] = useState('');
   const [showNewGoalDialog, setShowNewGoalDialog] = useState(false);
   const [newGoalName, setNewGoalName] = useState("");
   const [newGoalTarget, setNewGoalTarget] = useState("");
@@ -169,30 +128,6 @@ export default function SavingsPage() {
   // to savings goals so the overview is not redundant with the raw API balance.
   const goalsTotal = goals.reduce((sum, g) => sum + (typeof g.currentAmount === 'number' ? g.currentAmount : parseFloat(String(g.currentAmount) || '0')), 0);
   const totalSavings = apiBalance + goalsTotal;
-
-  const savingsAccounts: SavingsAccount[] = SAVINGS_ACCOUNT_TYPES.map((acct) => ({
-    ...acct,
-    balance: acct.id === "high-yield" ? apiBalance : 0,
-  }));
-
-  const handleSelectAccount = (account: SavingsAccount) => {
-    setSelectedAccount(account);
-    setShowDialog(true);
-  };
-
-  const handleDeposit = (account: SavingsAccount) => {
-    setSelectedAccount(account);
-    setShowDepositDialog(true);
-  };
-
-  const handleConfirmDeposit = () => {
-    if (depositAmount && parseFloat(depositAmount) > 0) {
-      // safely log the transaction attempt
-      logger.info("Confirming savings deposit", { accountId: selectedAccount?.id, amount: depositAmount }); 
-      setShowDepositDialog(false);
-      setDepositAmount("");
-    }
-  };
 
   return (
     <>


### PR DESCRIPTION
Closes #774
Closes #775
Closes #770
Closes #772

## Summary
This PR tightens two frontend areas that were carrying stale or incomplete wiring: the account KYC badge config and the savings page deposit-related dead code.

## What changed
- Uses the configured KYC badge variant returned by `getKycBadgeConfig`, so the helper's output is fully reflected by the rendered `Badge`.
- Removes the unused savings account model, static account type list, selected-account state, deposit-dialog state, and detached deposit handlers.
- Keeps the visible savings deposit and withdrawal actions routed through the existing `/savings/deposit` and `/savings/withdraw` flows, which avoids presenting unmounted dialog logic as if it were active.
- Leaves goal creation and API balance loading untouched.
