### PR TITLE
fix(tests): remove unused React import in app/send/page.test.tsx

### DIFF
--- a/app/send/page.test.tsx
+++ b/app/send/page.test.tsx
@@ -21,8 +21,6 @@
  * npm run test
  */
 
-import React from 'react';
-
 /**
  * TEST 1: Verify confirmedAmount state is set when opening confirm dialog
  * 


### PR DESCRIPTION
The React import on line 24 was dead code — the file contains no JSX or React API calls, only exported template literal strings and comments.

Resolves #776 (W2-F-025)
Severity: Low | Area: frontend/tests

## Description

<!-- What does this PR do? Provide a clear summary of the changes. -->

## Why

<!-- Why is this change needed? Link related issues with "Closes #123" or "Fixes #456". -->

## How to test

<!-- Step-by-step instructions so reviewers can verify the change locally. -->

1. 
2. 
3. 

## Screenshots / Recordings

<!-- Attach before/after screenshots or screen recordings for UI changes. Delete this section if not applicable. -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] Added or updated tests (if applicable)
- [ ] No new TypeScript or lint errors (`pnpm typecheck && pnpm lint`)
- [ ] Tested on mobile viewport (if UI change)
- [ ] Accessibility checked (keyboard navigation, screen reader)
closes #776 