### PR TITLE
[MEDIUM] types directory has overlapping type definitions

### DIFF
--- a/components/ui/api-error-display.tsx
+++ b/components/ui/api-error-display.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { AlertCircle, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import type { UIError } from "@/hooks/use-api-error";
+import type { UIError } from "@/types/api";
 
 interface ApiErrorDisplayProps {
   error: UIError;

--- a/hooks/__tests__/use-api-error.test.ts
+++ b/hooks/__tests__/use-api-error.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useApiError } from '../use-api-error';
-import type { ApiError } from '@/lib/api/client';
+import type { ApiError } from '@/types/api';
 
 function makeApiError(status: number, message: string): ApiError {
   const err = new Error(message) as ApiError;

--- a/hooks/use-api-error.ts
+++ b/hooks/use-api-error.ts
@@ -1,32 +1,7 @@
 import { useState, useCallback } from "react";
-import type { ApiError } from "@/lib/api/client";
+import type { ApiError, ApiErrorResponse, UIError } from "@/types/api";
 
-/**
- * Strict shape of an API error response from the backend.
- */
-export interface ApiErrorResponse {
-  status?: number;
-  message?: string;
-  details?: unknown;
-}
-
-/**
- * A mapped UI error with a human-readable message and an optional recovery action.
- */
-export interface UIError {
-  message: string;
-  action?: UIErrorAction;
-}
-
-export interface UIErrorAction {
-  label: string;
-  /** If set, render as a link. */
-  href?: string;
-  /** If set, call this when the action button is clicked. */
-  onClick?: () => void;
-  /** If true, the submit button should be disabled until this resolves. */
-  disableSubmitFor?: number; // milliseconds
-}
+export type { UIError, UIErrorAction } from "@/types/api";
 
 /**
  * Maps an API error status code to a user-friendly UIError.

--- a/lib/__tests__/api-error.test.ts
+++ b/lib/__tests__/api-error.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mapApiError } from '../../hooks/use-api-error';
 import { getApiErrorMessage } from '../api/client';
-import type { ApiError } from '../api/client';
+import type { ApiError } from '@/types/api';
 
 // ---------------------------------------------------------------------------
 // helpers

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -8,6 +8,9 @@
  * Timeout: Requests timeout after NEXT_PUBLIC_API_TIMEOUT ms (default 30000).
  * If caller provides AbortSignal, it aborts on either timeout or caller's signal.
  */
+import type { ApiError } from '@/types/api';
+
+export type { ApiError } from '@/types/api';
 
 let authErrorHandler: ((error: ApiError) => void) | null = null;
 
@@ -56,11 +59,6 @@ export function getApiErrorMessage(e: unknown): string {
 export interface RequestOptions {
   signal?: AbortSignal;
   token?: string;
-}
-
-export interface ApiError extends Error {
-  status?: number;
-  details?: unknown;
 }
 
 async function request<T>(

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -1,5 +1,6 @@
 export { get, post, patch, del, apiOpts } from './client';
-export type { RequestOptions, ApiError } from './client';
+export type { RequestOptions } from './client';
+export type { ApiError } from '@/types/api';
 export * as auth from './auth';
 export * as user from './user';
 export * as transfers from './transfers';

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -2,7 +2,7 @@ const isDebug = process.env.NEXT_PUBLIC_DEBUG === 'true' || process.env.NODE_ENV
 
 type LogLevel = 'info' | 'warn' | 'error' | 'debug';
 
-function logMessage(level: LogLevel, message: string, data?: any) {
+function logMessage(level: LogLevel, message: string, data?: unknown) {
   if (!isDebug) return;
 
   const logEntry = {
@@ -24,8 +24,8 @@ function logMessage(level: LogLevel, message: string, data?: any) {
 }
 
 export const logger = {
-  info: (message: string, data?: any) => logMessage('info', message, data),
-  warn: (message: string, data?: any) => logMessage('warn', message, data),
-  error: (message: string, data?: any) => logMessage('error', message, data),
-  debug: (message: string, data?: any) => logMessage('debug', message, data),
+  info: (message: string, data?: unknown) => logMessage('info', message, data),
+  warn: (message: string, data?: unknown) => logMessage('warn', message, data),
+  error: (message: string, data?: unknown) => logMessage('error', message, data),
+  debug: (message: string, data?: unknown) => logMessage('debug', message, data),
 };

--- a/types/api.ts
+++ b/types/api.ts
@@ -2,6 +2,29 @@
  * API request/response types (snake_case to match backend).
  */
 
+/** Error thrown by the API client for an unsuccessful HTTP response. */
+export interface ApiError extends Error {
+  status?: number;
+  details?: unknown;
+}
+
+/** Error payload returned by the backend before it is converted to an ApiError. */
+export type ApiErrorResponse = Partial<Pick<ApiError, 'message' | 'status' | 'details'>>;
+
+/** A recovery action presented to the user alongside a mapped API error. */
+export interface UIErrorAction {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  disableSubmitFor?: number;
+}
+
+/** A user-facing representation of an API error. */
+export interface UIError {
+  message: string;
+  action?: UIErrorAction;
+}
+
 // Auth
 export interface SigninResponse {
   api_key?: string; // Deprecated: now returned via httpOnly cookie only


### PR DESCRIPTION
close #684

Description

Replace loose any types in the logging API with unknown and centralize API/UI error types into a single canonical module. This improves TypeScript safety and consistency without changing runtime behavior.

Why
Replace data?: any with data?: unknown in the logging API to improve type safety.
Centralize ApiError, ApiErrorResponse, UIErrorAction, and UIError in types/api.ts.
Remove duplicated error type definitions and ensure the API client, error handling hook, UI error component, and tests use the same canonical types.
No runtime behavior changes were introduced.
How to test

Run the TypeScript checks:

pnpm typecheck

Run ESLint:

pnpm exec eslint

Check the diff for whitespace or patch issues:

git diff --check
Run the relevant Vitest tests when the test runner is available.
Screenshots / Recordings

Not applicable — this PR contains no UI changes.

Checklist
 Self-reviewed the diff
 Added or updated tests (if applicable)
 No new TypeScript errors (pnpm typecheck)
 Modified files checked with ESLint
 git diff --check passed
 Full lint passes — blocked by pre-existing repository lint errors outside the changed files
 Vitest tests executed — test runner was unavailable in the current environment
 No runtime behavior changes introduced