### PR TITLE
fix(routing): preserve locale in /account/* → /me/* redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -77,7 +77,37 @@ const nextConfig = {
   },
 
   async redirects() {
+    // Supported locale slugs – keep in sync with i18n/locales.ts
+    const localePattern = '(en|en-NG|en-KE|ar|ru|pl)';
+
     return [
+      // ── Locale-aware redirects (must come first so they take priority) ──
+      // Visitors arriving at /:locale/account/* keep their locale on the way
+      // to the canonical /me/* destination (fixes #766).
+      {
+        source: `/:locale${localePattern}/account`,
+        destination: '/:locale/me',
+        permanent: false,
+      },
+      {
+        source: `/:locale${localePattern}/account/profile`,
+        destination: '/:locale/me/profile',
+        permanent: false,
+      },
+      {
+        source: `/:locale${localePattern}/account/kyc`,
+        destination: '/:locale/me/kyc',
+        permanent: false,
+      },
+      {
+        source: `/:locale${localePattern}/account/recovery`,
+        destination: '/:locale/recovery',
+        permanent: false,
+      },
+
+      // ── Bare (non-localised) redirects ──────────────────────────────────
+      // Visitors without a locale prefix are redirected as before; the
+      // locale middleware will add the preferred locale afterwards.
       { source: '/account', destination: '/me', permanent: false },
       { source: '/account/profile', destination: '/me/profile', permanent: false },
       { source: '/account/kyc', destination: '/me/kyc', permanent: false },


### PR DESCRIPTION
The redirects() function in next.config.mjs was redirecting bare /account/* paths to /me/* without preserving the locale prefix, causing locale-aware users (e.g. /ar/account/profile) to land on /me/profile and lose their active locale.

Fix: Add locale-aware redirect rules that match
/:locale(en|en-NG|en-KE|ar|ru|pl)/account/* and forward to /:locale/me/*. The original bare redirects are kept as a fallback for paths that arrive without a locale segment (the locale middleware will apply the user preference afterwards).

Closes #766





## Checklist

- [ ] Self-reviewed the diff
- [ ] Added or updated tests (if applicable)
- [ ] No new TypeScript or lint errors (`pnpm typecheck && pnpm lint`)
- [ ] Tested on mobile viewport (if UI change)
- [ ] Accessibility checked (keyboard navigation, screen reader)
