### PR TITLE
fix(hooks): add AbortController + signal threading to prevent hung UI…

### DIFF
--- a/hooks/use-config.ts
+++ b/hooks/use-config.ts
@@ -52,47 +52,48 @@ export function useConfig(): UseConfigReturn {
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     setLoading(true);
     setError('');
 
-    // getAssetsConfig() already deduplicates in-flight requests and
-    // caches the result at module level. We just track staleness here.
+    // getAssetsConfig() deduplicates in-flight requests and caches the result
+    // at module level. We pass our AbortSignal so the underlying fetch is
+    // cancelled if the component unmounts before the response arrives.
     if (isFresh() && tick === 0) {
       // Cache is fresh — still call getAssetsConfig to get the cached value
-      getAssetsConfig()
+      getAssetsConfig({ signal: controller.signal })
         .then((cfg) => {
-          if (!cancelled) {
+          if (!controller.signal.aborted) {
             setConfig(cfg);
             setLoading(false);
           }
         })
         .catch(() => {
           // Shouldn't happen if cache is populated, but handle gracefully
-          if (!cancelled) setLoading(false);
+          if (!controller.signal.aborted) setLoading(false);
         });
       return () => {
-        cancelled = true;
+        controller.abort();
       };
     }
 
-    getAssetsConfig()
+    getAssetsConfig({ signal: controller.signal })
       .then((cfg) => {
         cachedAt = Date.now();
-        if (!cancelled) setConfig(cfg);
+        if (!controller.signal.aborted) setConfig(cfg);
       })
       .catch((e) => {
-        if (!cancelled)
-          setError(
-            e instanceof Error ? e.message : 'Failed to load configuration',
-          );
+        if (controller.signal.aborted) return;
+        setError(
+          e instanceof Error ? e.message : 'Failed to load configuration',
+        );
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [tick]);
 

--- a/hooks/use-rates.ts
+++ b/hooks/use-rates.ts
@@ -53,14 +53,15 @@ export function useRates(): UseRatesReturn {
       return;
     }
 
-    let cancelled = false;
+    const controller = new AbortController();
     setLoading(true);
     setError('');
 
-    // Deduplicate concurrent requests
+    // Deduplicate concurrent requests; pass the abort signal so the
+    // underlying fetch is cancelled when the component unmounts.
     const promise =
       inFlightPromise ??
-      (inFlightPromise = ratesApi.getRates(opts).finally(() => {
+      (inFlightPromise = ratesApi.getRates({ ...opts, signal: controller.signal }).finally(() => {
         inFlightPromise = null;
       }));
 
@@ -68,18 +69,18 @@ export function useRates(): UseRatesReturn {
       .then((data) => {
         cachedRates = data;
         cachedAt = Date.now();
-        if (!cancelled) setRates(data);
+        if (!controller.signal.aborted) setRates(data);
       })
       .catch((e) => {
-        if (!cancelled)
-          setError(e instanceof Error ? e.message : 'Failed to load rates');
+        if (controller.signal.aborted) return;
+        setError(e instanceof Error ? e.message : 'Failed to load rates');
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [opts.token, tick]);
 

--- a/lib/api/config.ts
+++ b/lib/api/config.ts
@@ -4,6 +4,7 @@
  * response: the assets don't change between requests within a session.
  */
 import { get } from "./client";
+import type { RequestOptions } from "./client";
 
 export interface PublicAssetsConfig {
   acbu: { code: string; issuer: string | null };
@@ -21,20 +22,24 @@ export interface PublicAssetsConfig {
 let cached: PublicAssetsConfig | null = null;
 let inFlight: Promise<PublicAssetsConfig> | null = null;
 
-export async function getAssetsConfig(): Promise<PublicAssetsConfig> {
+export async function getAssetsConfig(opts?: Pick<RequestOptions, 'signal'>): Promise<PublicAssetsConfig> {
   if (cached) return cached;
-  if (inFlight) return inFlight;
-  inFlight = get<PublicAssetsConfig>("/config/assets")
+  // If an in-flight request exists and no abort signal was provided, reuse it.
+  // If a signal is provided, start a fresh request so the caller can abort it independently.
+  if (inFlight && !opts?.signal) return inFlight;
+  const promise = get<PublicAssetsConfig>("/config/assets", opts)
     .then((cfg) => {
       cached = cfg;
       return cfg;
     })
     .finally(() => {
-      inFlight = null;
+      if (inFlight === promise) inFlight = null;
     });
-  return inFlight;
+  if (!opts?.signal) inFlight = promise;
+  return promise;
 }
 
 export function clearAssetsConfigCache(): void {
   cached = null;
+  inFlight = null;
 }

--- a/lib/api/rates.ts
+++ b/lib/api/rates.ts
@@ -19,6 +19,7 @@ export async function getRates(opts?: RequestOptions): Promise<RatesResponse> {
   return data;
 }
 
+
 export interface UseRatesResult {
   data: RatesResponse | null;
   loading: boolean;
@@ -39,23 +40,23 @@ export function useRates(opts?: RequestOptions): UseRatesResult {
   const refetch = useCallback(() => setTick((t) => t + 1), []);
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     setLoading(true);
     setError('');
-    getRates(opts)
+    getRates({ ...opts, signal: controller.signal })
       .then((d) => {
-        if (!cancelled) setData(d);
+        if (!controller.signal.aborted) setData(d);
       })
       .catch((e) => {
-        if (cancelled) return;
+        if (controller.signal.aborted) return;
         setData(null);
         setError(e instanceof Error ? e.message : 'Failed to load rates');
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       });
     return () => {
-      cancelled = true;
+      controller.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick]);


### PR DESCRIPTION
… on slow/stalled backend

Closes: #791  Medium-severity issue — Area: frontend/hooks
Affected files: hooks/use-rates.ts, hooks/use-config.ts, lib/api/rates.ts, lib/api/config.ts

## Problem

When the backend is slow or completely hung, the UI could be stuck in a permanent loading state. This happened because:

1. hooks/use-rates.ts and hooks/use-config.ts used only a boolean 'cancelled' flag on unmount. That flag stopped state updates, but the underlying fetch kept running. If the component remounted before the request finished, a stale or errored response could overwrite fresh state.

2. Neither hook passed an AbortSignal to the API layer, so the network request was never actually cancelled — just silently ignored.

3. lib/api/config.ts — getAssetsConfig() had no way to receive a signal, so even if a caller wanted to cancel, there was no path to do so.

4. lib/api/rates.ts — the inline useRates hook also used a 'cancelled' flag without an AbortController, and getRates() received no signal.

The existing client.ts already had full AbortSignal + timeout support (DEFAULT_TIMEOUT, default 30 s, configurable via NEXT_PUBLIC_API_TIMEOUT). The fix is to wire that existing infrastructure all the way up to the hooks.

## What was changed

### lib/api/config.ts
- Added 'import type { RequestOptions } from "./client"'
- getAssetsConfig() now accepts an optional 'opts?: Pick<RequestOptions, "signal">' parameter and passes it to get().
- The in-flight dedup logic was updated: if a signal is provided the request is NOT shared via the module-level inFlight reference (because the caller may abort it independently without cancelling a concurrent caller's request).
- clearAssetsConfigCache() now also nulls inFlight so a fresh call after a manual cache clear starts a new request cleanly.

### lib/api/rates.ts
- Replaced the boolean 'cancelled' flag in the inline useRates hook with an AbortController. The controller is created at the top of the effect, its signal is passed to getRates(), and controller.abort() is called in the cleanup function.
- Guarded all state-setter calls with '!controller.signal.aborted' instead of '!cancelled' — semantically identical but now also terminates the in-flight fetch at the network level.

### hooks/use-rates.ts
- Replaced 'let cancelled = false' with 'const controller = new AbortController()'.
- Passed '{ ...opts, signal: controller.signal }' to ratesApi.getRates() so the signal is forwarded through to client.ts's fetch call.
- Changed the cleanup return from '() => { cancelled = true }' to '() => { controller.abort() }' — this triggers an AbortError in the client, which the client recognises and does not retry (unlike a timeout).
- All state-setter guards updated from '!cancelled' to '!controller.signal.aborted'.

### hooks/use-config.ts
- Same AbortController pattern applied to both code paths in the effect (the fresh-cache fast path and the network-fetch path).
- getAssetsConfig() now receives '{ signal: controller.signal }' in both branches.
- Cleanup in both branches now calls controller.abort().

## Acceptance criteria met

- Loading state will clear within the configured timeout (default 30 s) because the client-level timeout fires controller.abort(), which the client translates to a 'Request timed out after N seconds' error.
- On component unmount the in-flight request is aborted immediately — loading state is never updated on an already-unmounted component.
- In-flight deduplication in use-rates.ts is preserved; concurrent consumers still share one network request.
- The config in-flight dedup is preserved for the common case (no signal), while signalled requests are kept independent so one caller cannot abort another's request.

## Description

<!-- What does this PR do? Provide a clear summary of the changes. -->

## Why

<!-- Why is this change needed? Link related issues with "Closes #123" or "Fixes #456". -->

## How to test

<!-- Step-by-step instructions so reviewers can verify the change locally. -->

1. 
2. 
3. 

## Screenshots / Recordings

<!-- Attach before/after screenshots or screen recordings for UI changes. Delete this section if not applicable. -->

## Checklist

- [ ] Self-reviewed the diff
- [ ] Added or updated tests (if applicable)
- [ ] No new TypeScript or lint errors (`pnpm typecheck && pnpm lint`)
- [ ] Tested on mobile viewport (if UI change)
- [ ] Accessibility checked (keyboard navigation, screen reader)
