### PR TITLE
Fix CSP violation reporting

### DIFF
--- a/app/__tests__/middleware.test.ts
+++ b/app/__tests__/middleware.test.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { middleware } from "../../middleware";
+
+describe("middleware CSP reporting", () => {
+  it("points CSP violations at the report endpoint", () => {
+    const request = new NextRequest("https://example.com/dashboard");
+
+    const response = middleware(request);
+    const policy = response.headers.get("Content-Security-Policy");
+
+    expect(policy).toContain("report-uri /api/csp-report");
+    expect(policy).toContain("default-src 'self'");
+    expect(policy).toContain("object-src 'none'");
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,6 +25,7 @@ export function middleware(request: NextRequest) {
     'base-uri': ["'self'"],
     'form-action': ["'self'"],
     'frame-ancestors': ["'none'"],
+    'report-uri': ['/api/csp-report'],
     'connect-src': [
       "'self'",
       "https://*.stellar.org",


### PR DESCRIPTION
Adds the CSP `report-uri` directive pointing to `/api/csp-report` so browser CSP violations reach the existing logging endpoint.

Also adds a focused middleware regression test covering the report endpoint and existing security directives.

Validation:
- `pnpm vitest run app/__tests__/middleware.test.ts`
- `pnpm exec eslint middleware.ts app/__tests__/middleware.test.ts`

Closes: #788