### PR TITLE
ci: add critical dependency audit

### DIFF
--- a/.github/workflows/frontend-qa.yml
+++ b/.github/workflows/frontend-qa.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run dependency audit
+        run: pnpm audit --audit-level=critical
+
       - name: Run typecheck
         run: pnpm typecheck
 

--- a/.github/workflows/frontend-qa.yml
+++ b/.github/workflows/frontend-qa.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

- Add a dependency audit step to the Frontend QA workflow.
- Fail CI when critical package vulnerabilities are reported.
- Keep the audit before typecheck, lint, tests, and build so security issues are surfaced early.

## Verification

- git diff --check passes.
- The workflow uses the repository's existing pnpm setup and frozen lockfile installation.

Closes #761