### PR TITLE
Fix OAuth callback Suspense boundary (#755); status update on #777, #752, #753

### DIFF
--- a/app/auth/oauth/callback/page.tsx
+++ b/app/auth/oauth/callback/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 
-export default function OAuthCallbackPage() {
+function OAuthCallbackContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const calledRef = useRef(false);
@@ -61,5 +61,19 @@ export default function OAuthCallbackPage() {
     <div className="flex min-h-screen items-center justify-center">
       <p className="text-muted-foreground">Signed in successfully. Redirecting...</p>
     </div>
+  );
+}
+
+export default function OAuthCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-muted-foreground">Completing sign-in...</p>
+        </div>
+      }
+    >
+      <OAuthCallbackContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

- #755 — Fixed. `app/auth/oauth/callback/page.tsx` called `useSearchParams()` without a Suspense boundary, which fails `next build` prerendering. Split the component into an inner `OAuthCallbackContent` and wrapped it in `<Suspense>` in the default export.
- #777 — Verified already fixed on `dev`. `loadingContacts` and the transfer history list are both wired into the JSX (contact `<Select>` loading state, and the History tab list) — no code change needed.
- #752 — Verified already fixed on `dev`. `.github/workflows/frontend-qa.yml` is valid YAML with a single job.
- #753 — Verified already fixed on `dev`. The workflow uses `actions/setup-node@v4`.

Closes #755 
Closes #777
Closes #752 
Closes #753 

## Test plan

- [ ] `next build` completes without the "useSearchParams() should be wrapped in a suspense boundary" error
- [ ] OAuth callback flow (success, missing code, invalid state) still behaves as before