### PR TITLE
fix: wrap useSearchParams in Suspense boundaries to prevent CSR bailout

### DIFF
--- a/app/auth/oauth/callback/page.tsx
+++ b/app/auth/oauth/callback/page.tsx
@@ -1,46 +1,48 @@
-'use client';
+"use client";
 
-import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useEffect, useRef, useState } from "react";
 
-export default function OAuthCallbackPage() {
+function OAuthCallbackContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const calledRef = useRef(false);
-  const [status, setStatus] = useState<'validating' | 'success' | 'error'>('validating');
-  const [errorMessage, setErrorMessage] = useState('');
+  const [status, setStatus] = useState<"validating" | "success" | "error">(
+    "validating",
+  );
+  const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
     if (calledRef.current) return;
     calledRef.current = true;
 
-    const code = searchParams.get('code');
-    const state = searchParams.get('state');
+    const code = searchParams.get("code");
+    const state = searchParams.get("state");
 
     if (!code) {
-      setStatus('error');
-      setErrorMessage('Missing authorization code.');
+      setStatus("error");
+      setErrorMessage("Missing authorization code.");
       return;
     }
 
-    const storedState = sessionStorage.getItem('oauth_state');
+    const storedState = sessionStorage.getItem("oauth_state");
 
     if (!state || !storedState || state !== storedState) {
-      setStatus('error');
-      setErrorMessage('Invalid state parameter. Possible CSRF attack.');
+      setStatus("error");
+      setErrorMessage("Invalid state parameter. Possible CSRF attack.");
       return;
     }
 
-    sessionStorage.removeItem('oauth_state');
+    sessionStorage.removeItem("oauth_state");
 
-    setStatus('success');
+    setStatus("success");
 
-    const returnPath = sessionStorage.getItem('oauth_return_path') || '/';
-    sessionStorage.removeItem('oauth_return_path');
+    const returnPath = sessionStorage.getItem("oauth_return_path") || "/";
+    sessionStorage.removeItem("oauth_return_path");
     router.replace(returnPath);
   }, [searchParams, router]);
 
-  if (status === 'validating') {
+  if (status === "validating") {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p className="text-muted-foreground">Completing sign-in...</p>
@@ -48,10 +50,12 @@ export default function OAuthCallbackPage() {
     );
   }
 
-  if (status === 'error') {
+  if (status === "error") {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-4">
-        <h1 className="text-xl font-semibold text-destructive">Authentication Error</h1>
+        <h1 className="text-destructive text-xl font-semibold">
+          Authentication Error
+        </h1>
         <p className="text-muted-foreground">{errorMessage}</p>
       </div>
     );
@@ -59,7 +63,23 @@ export default function OAuthCallbackPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <p className="text-muted-foreground">Signed in successfully. Redirecting...</p>
+      <p className="text-muted-foreground">
+        Signed in successfully. Redirecting...
+      </p>
     </div>
+  );
+}
+
+export default function OAuthCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-muted-foreground">Completing sign-in...</p>
+        </div>
+      }
+    >
+      <OAuthCallbackContent />
+    </Suspense>
   );
 }

--- a/app/me/kyc/upload/page.tsx
+++ b/app/me/kyc/upload/page.tsx
@@ -1,32 +1,35 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect, useRef } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import React, { Suspense, useState, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
-import Link from 'next/link';
-import { PageContainer } from '@/components/layout/page-container';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { ArrowLeft } from 'lucide-react';
-import { ErrorBoundary } from '@/components/error-boundary';
-import { useApiOpts } from '@/hooks/use-api';
-import * as kycApi from '@/lib/api/kyc';
-import type { KycDocumentKind } from '@/lib/api/kyc';
+import Link from "next/link";
+import { PageContainer } from "@/components/layout/page-container";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { useApiOpts } from "@/hooks/use-api";
+import * as kycApi from "@/lib/api/kyc";
+import type { KycDocumentKind } from "@/lib/api/kyc";
 
 const KINDS: { kind: KycDocumentKind; label: string }[] = [
-  { kind: 'id_front', label: 'ID (front)' },
-  { kind: 'id_back', label: 'ID (back)' },
-  { kind: 'selfie', label: 'Selfie' },
+  { kind: "id_front", label: "ID (front)" },
+  { kind: "id_back", label: "ID (back)" },
+  { kind: "selfie", label: "Selfie" },
 ];
 
 function UploadWidget() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const applicationId = searchParams.get('applicationId') ?? '';
+  const applicationId = searchParams.get("applicationId") ?? "";
   const opts = useApiOpts();
-  const [storageRefs, setStorageRefs] = useState<Record<KycDocumentKind, string>>({ id_front: '', id_back: '', selfie: '' });
+  const [storageRefs, setStorageRefs] = useState<
+    Record<KycDocumentKind, string>
+  >({ id_front: "", id_back: "", selfie: "" });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -38,42 +41,52 @@ function UploadWidget() {
     };
   }, []);
 
-  const handleFile = async (kind: KycDocumentKind, file: File | null) => {      
+  const handleFile = async (kind: KycDocumentKind, file: File | null) => {
     if (!applicationId || !file) return;
-    setError('');
+    setError("");
     try {
-      const { upload_url, storage_ref } = await kycApi.getUploadUrl(applicationId, kind, opts);
+      const { upload_url, storage_ref } = await kycApi.getUploadUrl(
+        applicationId,
+        kind,
+        opts,
+      );
       const res = await fetch(upload_url, {
-        method: 'PUT',
+        method: "PUT",
         body: file,
-        headers: { 'Content-Type': file.type || 'application/octet-stream' },   
+        headers: { "Content-Type": file.type || "application/octet-stream" },
       });
-      if (!res.ok) throw new Error('Upload failed');
+      if (!res.ok) throw new Error("Upload failed");
       setStorageRefs((prev) => ({ ...prev, [kind]: storage_ref }));
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Upload failed');
+      setError(e instanceof Error ? e.message : "Upload failed");
     }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const docs = KINDS.filter((k) => storageRefs[k.kind]).map((k) => ({ kind: k.kind, storage_ref: storageRefs[k.kind] }));
+    const docs = KINDS.filter((k) => storageRefs[k.kind]).map((k) => ({
+      kind: k.kind,
+      storage_ref: storageRefs[k.kind],
+    }));
     if (docs.length === 0) {
-      setError('Upload at least one document');
+      setError("Upload at least one document");
       return;
     }
-    setError('');
+    setError("");
     setLoading(true);
     try {
       await kycApi.patchApplicationDocuments(
         applicationId,
         { documents: docs },
-        opts
+        opts,
       );
       setSuccess(true);
-      timeoutRef.current = setTimeout(() => router.push(`/me/kyc/${applicationId}`), 1500);
+      timeoutRef.current = setTimeout(
+        () => router.push(`/me/kyc/${applicationId}`),
+        1500,
+      );
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Submit failed');
+      setError(e instanceof Error ? e.message : "Submit failed");
     } finally {
       setLoading(false);
     }
@@ -82,15 +95,25 @@ function UploadWidget() {
   if (!applicationId) {
     return (
       <>
-        <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
-          <div className="px-4 py-3 flex items-center gap-3">
-            <Link href="/me/kyc"><ArrowLeft className="w-5 h-5 text-primary" /></Link>
-            <h1 className="text-lg font-bold text-foreground">Upload documents</h1>
+        <div className="border-border bg-card/95 sticky top-0 z-10 border-b backdrop-blur-sm">
+          <div className="flex items-center gap-3 px-4 py-3">
+            <Link href="/me/kyc">
+              <ArrowLeft className="text-primary h-5 w-5" />
+            </Link>
+            <h1 className="text-foreground text-lg font-bold">
+              Upload documents
+            </h1>
           </div>
         </div>
         <PageContainer>
-          <p className="text-muted-foreground">No application selected. Start a KYC application first.</p>
-          <Link href="/me/kyc/start"><Button variant="outline" className="mt-3">Start KYC</Button></Link>
+          <p className="text-muted-foreground">
+            No application selected. Start a KYC application first.
+          </p>
+          <Link href="/me/kyc/start">
+            <Button variant="outline" className="mt-3">
+              Start KYC
+            </Button>
+          </Link>
         </PageContainer>
       </>
     );
@@ -98,32 +121,75 @@ function UploadWidget() {
 
   return (
     <>
-      <div className="sticky top-0 z-10 border-b border-border bg-card/95 backdrop-blur-sm">
-        <div className="px-4 py-3 flex items-center gap-3">
-          <Link href={`/me/kyc/${applicationId}`}><ArrowLeft className="w-5 h-5 text-primary" /></Link>
-          <h1 className="text-lg font-bold text-foreground">Upload documents</h1>
+      <div className="border-border bg-card/95 sticky top-0 z-10 border-b backdrop-blur-sm">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <Link href={`/me/kyc/${applicationId}`}>
+            <ArrowLeft className="text-primary h-5 w-5" />
+          </Link>
+          <h1 className="text-foreground text-lg font-bold">
+            Upload documents
+          </h1>
         </div>
       </div>
       <PageContainer>
-        <Card className="border-border p-4 space-y-4">
-          <p className="text-sm text-muted-foreground">Upload id_front, id_back, and selfie. Then submit.</p>
-          {error && <p className="text-sm text-destructive">{error}</p>}        
-          {success && <p className="text-sm text-green-600">Documents submitted.</p>}
+        <Card className="border-border space-y-4 p-4">
+          <p className="text-muted-foreground text-sm">
+            Upload id_front, id_back, and selfie. Then submit.
+          </p>
+          {error && <p className="text-destructive text-sm">{error}</p>}
+          {success && (
+            <p className="text-sm text-green-600">Documents submitted.</p>
+          )}
           <form onSubmit={handleSubmit} className="space-y-4">
             {KINDS.map(({ kind, label }) => (
               <div key={kind}>
-                <label className="text-sm font-medium text-foreground mb-2 block">{label}</label>
+                <label className="text-foreground mb-2 block text-sm font-medium">
+                  {label}
+                </label>
                 <input
                   type="file"
                   accept="image/*,.pdf"
-                  className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-primary file:text-primary-foreground"
-                  onChange={(e) => handleFile(kind, e.target.files?.[0] ?? null)}
+                  className="text-muted-foreground file:bg-primary file:text-primary-foreground block w-full text-sm file:mr-4 file:rounded file:border-0 file:px-4 file:py-2"
+                  onChange={(e) =>
+                    handleFile(kind, e.target.files?.[0] ?? null)
+                  }
                 />
-                {storageRefs[kind] && <span className="text-xs text-green-600">Uploaded</span>}
+                {storageRefs[kind] && (
+                  <span className="text-xs text-green-600">Uploaded</span>
+                )}
               </div>
             ))}
-            <Button type="submit" disabled={loading || !storageRefs.id_front}>Submit documents</Button>
+            <Button type="submit" disabled={loading || !storageRefs.id_front}>
+              Submit documents
+            </Button>
           </form>
+        </Card>
+      </PageContainer>
+    </>
+  );
+}
+
+function KycUploadSkeleton() {
+  return (
+    <>
+      <div className="border-border bg-card/95 sticky top-0 z-10 border-b backdrop-blur-sm">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <Skeleton className="h-5 w-5" />
+          <Skeleton className="h-5 w-36" />
+        </div>
+      </div>
+      <PageContainer>
+        <Card className="border-border space-y-4 p-4">
+          <Skeleton className="h-4 w-64" />
+          <div className="space-y-4">
+            {KINDS.map(({ kind }) => (
+              <div key={kind} className="space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <Skeleton className="h-10 w-full" />
+          </div>
         </Card>
       </PageContainer>
     </>
@@ -133,7 +199,9 @@ function UploadWidget() {
 export default function KycUploadPage() {
   return (
     <ErrorBoundary>
-      <UploadWidget />
+      <Suspense fallback={<KycUploadSkeleton />}>
+        <UploadWidget />
+      </Suspense>
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Description

This PR wraps all `useSearchParams()` calls that were missing `<Suspense>` boundaries in `Suspense` with appropriate fallback UI, eliminating the CSR bailout warning described in issue #797.

Two files were fixed:

1. **`app/auth/oauth/callback/page.tsx`** — Extracted the component body into `OAuthCallbackContent()` and created a new default export `OAuthCallbackPage()` that wraps it in `<Suspense>` with a fallback matching the existing "Completing sign-in..." loading state.

2. **`app/me/kyc/upload/page.tsx`** — Added a `KycUploadSkeleton` component (using the project's existing `Skeleton` UI primitive) that mirrors the page layout, and wrapped `<UploadWidget />` in `<Suspense fallback={<KycUploadSkeleton />}>` inside the existing `<ErrorBoundary>`.

The other two files using `useSearchParams` (`app/[locale]/auth/signin/page.tsx` and `app/burn/page.tsx`) were already correctly wrapped in `<Suspense>` and required no changes.

## Why

`useSearchParams()` in Next.js causes pages to bail out to client-side rendering on slow networks unless wrapped in a `<Suspense>` boundary. This triggers a CSR bailout warning in dev logs and degrades performance for users on slow connections.

Closes #797

## How to test

1. Run `pnpm dev` and navigate to `/auth/oauth/callback?code=test&state=test` — the page should show the "Completing sign-in..." fallback during Suspense, then render the callback content without a bailout warning in the terminal.
2. Navigate to `/me/kyc/upload?applicationId=test` — the page should show the skeleton loader during Suspense, then render the upload form.
3. Run `pnpm build` and verify there are no `useSearchParams` CSR bailout warnings in the build output.
4. Verify search params still parse correctly on both pages (e.g., `redirect` param on signin, `applicationId` on KYC upload).

## Screenshots / Recordings

N/A — No visual changes to the rendered pages. The Suspense fallbacks match existing loading states.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added or updated tests (if applicable)
- [x] No new TypeScript or lint errors (`pnpm typecheck && pnpm lint`)
- [ ] Tested on mobile viewport (if UI change)
- [x] Accessibility checked (keyboard navigation, screen reader)