### PR TITLE
perf(images): configure Next.js image optimisation pipeline

### DIFF
--- a/docs/adr/image-pipeline.md
+++ b/docs/adr/image-pipeline.md
@@ -1,0 +1,56 @@
+# ADR: Image Optimisation Pipeline
+
+**Status:** Accepted  
+**Date:** 2026-08-27  
+**Area:** frontend/perf
+
+---
+
+## Context
+
+A performance audit (severity: low) flagged that the project lacked an explicit
+image configuration in `next.config.mjs`, raising two concerns:
+
+1. **`unoptimized: true` might be set** — disabling the built-in resize/format
+   pipeline and increasing bandwidth for end users.
+2. **No remote-pattern allowlist** — meaning any future remote image URL would
+   either be blocked by Next.js or require disabling optimisation globally.
+3. **No cache floor** — the default `minimumCacheTTL` (0 s) allows the image
+   endpoint to be hammered on every request.
+
+## Decision
+
+Enable and explicitly document the image optimisation pipeline in
+`next.config.mjs`.  Specifically:
+
+| Setting | Value | Reason |
+|---|---|---|
+| `unoptimized` | not set (defaults `false`) | Optimisation is ON; Next.js resizes and converts images at request time via `/_next/image`. |
+| `formats` | `['image/avif', 'image/webp']` | AVIF gives ~50 % better compression than WebP; WebP is the fallback for browsers that don't support AVIF. |
+| `minimumCacheTTL` | `60` (seconds) | Prevents repeated reprocessing of the same image within a 60-second window. CDN/Vercel Edge may cache longer based on `Cache-Control` headers. |
+| `remotePatterns` | API origin from `NEXT_PUBLIC_API_BASE_URL` | Pre-authorises user avatars and media served from the backend without opening a wildcard allowlist. Additional CDN origins must be added here explicitly. |
+
+## Consequences
+
+- **Positive:** Reduced bandwidth for end users (modern format delivery).
+  Lower CPU load on the image endpoint (cache floor).
+  Secure-by-default remote images (allowlist, not open wildcard).
+- **Neutral:** Build-time resolution of `NEXT_PUBLIC_API_BASE_URL` for the
+  remote pattern — requires the variable to be set in CI/CD environments.
+  Local development without `.env.local` simply has an empty `remotePatterns`
+  array, which is fine because all current images are local static assets.
+- **Negative / trade-off:** AVIF encoding is slower than WebP; this is
+  acceptable because the image endpoint caches the result after the first
+  request.
+
+## Adding New Remote Image Sources
+
+Do **not** set `unoptimized: true` to work around a missing hostname.
+Instead, add an entry to the `remotePatterns` array in `next.config.mjs`:
+
+```js
+{ protocol: 'https', hostname: 'your-cdn.example.com', pathname: '/**' }
+```
+
+Commit the change with a brief comment explaining which service hosts those
+images and why.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,6 +40,50 @@ const nextConfig = {
   // Don't advertise the framework to reduce attack surface
   poweredByHeader: false,
 
+  /**
+   * Image optimisation — intentional configuration (see docs/adr/image-pipeline.md)
+   *
+   * Optimisation is ENABLED (unoptimized is not set / defaults to false).
+   * Next.js will resize, convert to modern formats, and serve images through
+   * the built-in /_next/image endpoint.
+   *
+   * Remote patterns:
+   *   - The API origin (NEXT_PUBLIC_API_BASE_URL) is whitelisted so that
+   *     user avatars, KYC documents, and other media served from the backend
+   *     can be loaded via next/image without disabling optimisation.
+   *   - Add additional hostnames here rather than setting unoptimized:true.
+   *
+   * Caching:
+   *   - minimumCacheTTL: 60 s floor to avoid thrashing the image endpoint
+   *     on rapidly-changing assets.  CDN/Vercel Edge will respect
+   *     Cache-Control headers emitted by the image handler above this floor.
+   *
+   * Formats:
+   *   - avif first (best compression), webp fallback; browsers that support
+   *     neither receive the original format (jpeg/png).
+   */
+  images: {
+    formats: ['image/avif', 'image/webp'],
+    minimumCacheTTL: 60,
+    remotePatterns: [
+      // API origin — derives hostname from the runtime env var at build time.
+      // If the env var is absent (e.g. during local dev without .env.local)
+      // the pattern is simply omitted; add a localhost entry below if needed.
+      ...(process.env.NEXT_PUBLIC_API_BASE_URL
+        ? [
+            {
+              protocol: 'https',
+              hostname: new URL(process.env.NEXT_PUBLIC_API_BASE_URL).hostname,
+              pathname: '/**',
+            },
+          ]
+        : []),
+      // ── Add project-specific CDN / storage origins below ────────────────
+      // Example — uncomment and fill in when a dedicated media CDN is added:
+      // { protocol: 'https', hostname: 'media.acbu.io', pathname: '/**' },
+    ],
+  },
+
   // Emit hidden source maps in production so error stack traces can be
   // resolved to original source.  The maps are uploaded to the error
   // tracking service and then stripped from the public build output


### PR DESCRIPTION
onfigure Next.js image optimisation pipeline

## Summary

Resolves a low-severity performance audit finding (frontend/perf) that flagged 
the absence of an explicit image configuration in next.config.mjs.

The image pipeline was already optimised by default (Next.js optimisation was 
never disabled), but there was no documented intent, no format preference, no 
cache floor, and no remote-pattern allowlist for backend-hosted media.

## Changes

next.config.mjs
- formats: ['image/avif', 'image/webp'] — delivers AVIF to supporting browsers (
~50% smaller than WebP), WebP as fallback, original format otherwise.
- minimumCacheTTL: 60 — 60-second cache floor on the /_next/image endpoint to 
prevent repeated reprocessing of the same source image.
- remotePatterns — API origin derived from NEXT_PUBLIC_API_BASE_URL at build 
time, so backend-hosted media (avatars, KYC files, etc.) works without opening a
wildcard allowlist. Gracefully omitted when the env var is absent (local dev).

docs/adr/image-pipeline.md (new)
- ADR documenting the deliberate configuration choices, their trade-offs, and 
the standing rule: add entries to remotePatterns rather than ever setting 
unoptimized: true.

## Testing

- No functional change to existing image rendering (all current <Image> usages 
load local static assets and are unaffected).
- Format negotiation and caching behaviour can be verified by inspecting 
Content-Type and Cache-Control response headers on /_next/image requests in a 
production build.

## Acceptance criterion

Image pipeline is intentional and documented. ✅
closes #800