### PR TITLE
fix: remove console.log from GlobalErrorHandler to resolve no-console…

### DIFF
--- a/components/global-error-handler.tsx
+++ b/components/global-error-handler.tsx
@@ -11,11 +11,6 @@ export function GlobalErrorHandler() {
   useEffect(() => {
     // Set up global error handling on mount
     setupGlobalErrorHandling();
-    
-    // Log that error handling is active
-    if (process.env.NODE_ENV === 'development') {
-      console.log('[GlobalErrorHandler] Error reporting initialized');
-    }
   }, []);
 
   // This component doesn't render anything


### PR DESCRIPTION

  fix: remove console.log from GlobalErrorHandler
  
  Removes the development-only console.log call in GlobalErrorHandler that was leaking
  initialization info to the browser console.
  
  Changes
  
  - Removed console.log('[GlobalErrorHandler] Error reporting initialized') from the useEffect in
  components/global-error-handler.tsx
  - Error handling initialization still works as before via setupGlobalErrorHandling(); the
  removed log provided no diagnostic value
  
  Testing
  
  - Lint passes clean with no no-console warnings on the affected file

▸ Close #778 