### PR TITLE
fix(auth, a11y): oauth redirect validation and focus-trap test typing

### DIFF
--- a/app/[locale]/auth/oauth/callback/page.tsx
+++ b/app/[locale]/auth/oauth/callback/page.tsx
@@ -1,7 +1,28 @@
 "use client";
 
-import { useSearchParams, useRouter } from 'next/navigation';
-import { Suspense, useEffect, useRef, useState } from 'react';
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useEffect, useRef, useState } from "react";
+
+export function getSafeOAuthReturnPath(value: string | null): string {
+  if (!value) {
+    return "/";
+  }
+
+  const trimmedValue = value.trim();
+
+  if (
+    !trimmedValue ||
+    !trimmedValue.startsWith("/") ||
+    trimmedValue.startsWith("//") ||
+    /^https?:\/\//i.test(trimmedValue) ||
+    /^javascript:/i.test(trimmedValue) ||
+    /^data:/i.test(trimmedValue)
+  ) {
+    return "/";
+  }
+
+  return trimmedValue;
+}
 
 function OAuthCallbackContent() {
   const searchParams = useSearchParams();
@@ -37,7 +58,9 @@ function OAuthCallbackContent() {
 
     setStatus("success");
 
-    const returnPath = sessionStorage.getItem("oauth_return_path") || "/";
+    const returnPath = getSafeOAuthReturnPath(
+      sessionStorage.getItem("oauth_return_path"),
+    );
     sessionStorage.removeItem("oauth_return_path");
     router.replace(returnPath);
   }, [searchParams, router]);

--- a/hooks/__tests__/use-focus-trap.test.ts
+++ b/hooks/__tests__/use-focus-trap.test.ts
@@ -1,192 +1,207 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-import { useFocusTrap } from '../use-focus-trap'
-import React from 'react'
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFocusTrap } from "../use-focus-trap";
+import React from "react";
 
-describe('useFocusTrap', () => {
-  let container: HTMLDivElement
+describe("useFocusTrap", () => {
+  let container: HTMLDivElement;
 
   beforeEach(() => {
     // Create a test container with focusable elements
-    container = document.createElement('div')
+    container = document.createElement("div");
     container.innerHTML = `
       <button id="button-1">Button 1</button>
       <input id="input-1" type="text" />
       <a id="link-1" href="#">Link 1</a>
       <button id="button-2">Button 2</button>
-    `
-    document.body.appendChild(container)
-  })
+    `;
+    document.body.appendChild(container);
+  });
 
   afterEach(() => {
-    document.body.removeChild(container)
-  })
+    document.body.removeChild(container);
+  });
 
-  it('traps focus on Tab from last element to first', () => {
-    const containerRef = React.createRef<HTMLDivElement>()
-    // Mock the ref
-    ;(containerRef as any).current = container
+  it("traps focus on Tab from last element to first", () => {
+    const containerRef: React.RefObject<HTMLDivElement> = {
+      current: container,
+    };
 
-    renderHook(() => useFocusTrap(containerRef, { isActive: true }))
+    renderHook(() => useFocusTrap(containerRef, { isActive: true }));
 
-    const lastButton = container.querySelector('#button-2') as HTMLButtonElement
-    lastButton.focus()
-    expect(document.activeElement).toBe(lastButton)
+    const lastButton = container.querySelector(
+      "#button-2",
+    ) as HTMLButtonElement;
+    lastButton.focus();
+    expect(document.activeElement).toBe(lastButton);
 
     // Simulate Tab key on last element
-    const event = new KeyboardEvent('keydown', {
-      key: 'Tab',
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
       bubbles: true,
-    })
+    });
     act(() => {
-      container.dispatchEvent(event)
-    })
+      container.dispatchEvent(event);
+    });
 
     // Focus should wrap to first element
-    const firstButton = container.querySelector('#button-1') as HTMLButtonElement
-    expect(document.activeElement).toBe(firstButton)
-  })
+    const firstButton = container.querySelector(
+      "#button-1",
+    ) as HTMLButtonElement;
+    expect(document.activeElement).toBe(firstButton);
+  });
 
-  it('traps focus on Shift+Tab from first element to last', () => {
-    const containerRef = React.createRef<HTMLDivElement>()
-    ;(containerRef as any).current = container
+  it("traps focus on Shift+Tab from first element to last", () => {
+    const containerRef: React.RefObject<HTMLDivElement> = {
+      current: container,
+    };
 
-    renderHook(() => useFocusTrap(containerRef, { isActive: true }))
+    renderHook(() => useFocusTrap(containerRef, { isActive: true }));
 
-    const firstButton = container.querySelector('#button-1') as HTMLButtonElement
-    firstButton.focus()
-    expect(document.activeElement).toBe(firstButton)
+    const firstButton = container.querySelector(
+      "#button-1",
+    ) as HTMLButtonElement;
+    firstButton.focus();
+    expect(document.activeElement).toBe(firstButton);
 
     // Simulate Shift+Tab key on first element
-    const event = new KeyboardEvent('keydown', {
-      key: 'Tab',
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
       shiftKey: true,
       bubbles: true,
-    })
+    });
     act(() => {
-      container.dispatchEvent(event)
-    })
+      container.dispatchEvent(event);
+    });
 
     // Focus should wrap to last element
-    const lastButton = container.querySelector('#button-2') as HTMLButtonElement
-    expect(document.activeElement).toBe(lastButton)
-  })
+    const lastButton = container.querySelector(
+      "#button-2",
+    ) as HTMLButtonElement;
+    expect(document.activeElement).toBe(lastButton);
+  });
 
-  it('does not trap focus when inactive', () => {
-    const containerRef = React.createRef<HTMLDivElement>()
-    ;(containerRef as any).current = container
+  it("does not trap focus when inactive", () => {
+    const containerRef: React.RefObject<HTMLDivElement> = {
+      current: container,
+    };
 
-    renderHook(() => useFocusTrap(containerRef, { isActive: false }))
+    renderHook(() => useFocusTrap(containerRef, { isActive: false }));
 
-    const lastButton = container.querySelector('#button-2') as HTMLButtonElement
-    lastButton.focus()
+    const lastButton = container.querySelector(
+      "#button-2",
+    ) as HTMLButtonElement;
+    lastButton.focus();
 
     // Simulate Tab key
-    const event = new KeyboardEvent('keydown', {
-      key: 'Tab',
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
       bubbles: true,
-    })
+    });
 
     // Should not prevent default when inactive
-    expect(event.defaultPrevented).toBe(false)
-  })
+    expect(event.defaultPrevented).toBe(false);
+  });
 
-  it('finds various focusable element types', () => {
-    const containerRef = React.createRef<HTMLDivElement>()
-    ;(containerRef as any).current = container
+  it("finds various focusable element types", () => {
+    const containerRef: React.RefObject<HTMLDivElement> = {
+      current: container,
+    };
 
-    renderHook(() => useFocusTrap(containerRef, { isActive: true }))
+    renderHook(() => useFocusTrap(containerRef, { isActive: true }));
 
     // Container has button, input, link, button - all focusable
     // If we can Tab to different elements, the focus trap is finding them
-    expect(true).toBe(true) // Placeholder assertion
-  })
+    expect(true).toBe(true); // Placeholder assertion
+  });
 
-  it('ignores disabled elements', () => {
-    const disabledContainer = document.createElement('div')
+  it("ignores disabled elements", () => {
+    const disabledContainer = document.createElement("div");
     disabledContainer.innerHTML = `
       <button id="disabled-button-1">Button 1</button>
       <button id="disabled-button-2" disabled>Button 2 (Disabled)</button>
       <button id="disabled-button-3">Button 3</button>
-    `
-    document.body.appendChild(disabledContainer)
+    `;
+    document.body.appendChild(disabledContainer);
 
-    const containerRef = React.createRef<HTMLDivElement>()
-    ;(containerRef as any).current = disabledContainer
+    const containerRef: React.RefObject<HTMLDivElement> = {
+      current: disabledContainer,
+    };
 
-    renderHook(() => useFocusTrap(containerRef, { isActive: true }))
+    renderHook(() => useFocusTrap(containerRef, { isActive: true }));
 
     const firstButton = disabledContainer.querySelector(
-      '#disabled-button-1',
-    ) as HTMLButtonElement
+      "#disabled-button-1",
+    ) as HTMLButtonElement;
     const thirdButton = disabledContainer.querySelector(
-      '#disabled-button-3',
-    ) as HTMLButtonElement
+      "#disabled-button-3",
+    ) as HTMLButtonElement;
 
     if (!firstButton || !thirdButton) {
-      document.body.removeChild(disabledContainer)
-      return
+      document.body.removeChild(disabledContainer);
+      return;
     }
 
-    firstButton.focus()
+    firstButton.focus();
 
     // Simulate Shift+Tab from first to wrap around
-    const event = new KeyboardEvent('keydown', {
-      key: 'Tab',
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
       shiftKey: true,
       bubbles: true,
-    })
+    });
     act(() => {
-      disabledContainer.dispatchEvent(event)
-    })
+      disabledContainer.dispatchEvent(event);
+    });
 
     // Should skip disabled button and focus on the last focusable (button-3)
-    expect(document.activeElement).toBe(thirdButton)
+    expect(document.activeElement).toBe(thirdButton);
 
-    document.body.removeChild(disabledContainer)
-  })
+    document.body.removeChild(disabledContainer);
+  });
 
-  it('ignores hidden elements', () => {
-    const hiddenContainer = document.createElement('div')
+  it("ignores hidden elements", () => {
+    const hiddenContainer = document.createElement("div");
     hiddenContainer.innerHTML = `
       <button id="hidden-button-1">Button 1</button>
       <button id="hidden-button-2" style="display: none;">Button 2 (Hidden)</button>
       <button id="hidden-button-3">Button 3</button>
-    `
-    document.body.appendChild(hiddenContainer)
+    `;
+    document.body.appendChild(hiddenContainer);
 
-    const containerRef = React.createRef<HTMLDivElement>()
-    ;(containerRef as any).current = hiddenContainer
+    const containerRef: React.RefObject<HTMLDivElement> = {
+      current: hiddenContainer,
+    };
 
-    renderHook(() => useFocusTrap(containerRef, { isActive: true }))
+    renderHook(() => useFocusTrap(containerRef, { isActive: true }));
 
     const firstButton = hiddenContainer.querySelector(
-      '#hidden-button-1',
-    ) as HTMLButtonElement
+      "#hidden-button-1",
+    ) as HTMLButtonElement;
     const thirdButton = hiddenContainer.querySelector(
-      '#hidden-button-3',
-    ) as HTMLButtonElement
+      "#hidden-button-3",
+    ) as HTMLButtonElement;
 
     if (!firstButton || !thirdButton) {
-      document.body.removeChild(hiddenContainer)
-      return
+      document.body.removeChild(hiddenContainer);
+      return;
     }
 
-    firstButton.focus()
+    firstButton.focus();
 
     // Simulate Shift+Tab from first to wrap around
-    const event = new KeyboardEvent('keydown', {
-      key: 'Tab',
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
       shiftKey: true,
       bubbles: true,
-    })
+    });
     act(() => {
-      hiddenContainer.dispatchEvent(event)
-    })
+      hiddenContainer.dispatchEvent(event);
+    });
 
     // Should skip hidden button and focus on the last focusable (button-3)
-    expect(document.activeElement).toBe(thirdButton)
+    expect(document.activeElement).toBe(thirdButton);
 
-    document.body.removeChild(hiddenContainer)
-  })
-})
+    document.body.removeChild(hiddenContainer);
+  });
+});


### PR DESCRIPTION
## Overview

This pull request addresses two security and quality issues:
- **Issue #785 (W2-F-034)**: OAuth callback redirect validation  
- **Issue #779 (W2-F-028)**: Focus-trap hook test typing cleanup

## Issue #785 - W2-F-034: Validate OAuth Callback Redirect Target

### Problem
The OAuth callback page reads the redirect target directly from `sessionStorage` without validation, creating an open redirect vulnerability. Any code with sessionStorage access can control post-login navigation.

**Root cause**: `app/[locale]/auth/oauth/callback/page.tsx` lines 38-40
- `returnPath = sessionStorage.getItem('oauth_return_path') || '/'`
- `router.replace(returnPath)` // Unvalidated redirect

### Solution  
Added `getSafeOAuthReturnPath()` validator function that:
- Validates path starts with `/` (relative URL only)
- Rejects protocol-relative paths (`//evil.com`)
- Blocks absolute URLs (`http://`, `https://`)
- Blocks dangerous schemes (`javascript:`, `data:`)
- Falls back to `/` for any invalid path

### Impact
External/malicious return paths are rejected and safely redirected to home.

---

## Issue #779 - W2-F-028: Clean Up Focus-Trap Hook Test Typing

### Problem
Focus-trap test file had quality issues:
- Unused `vi` import from vitest (line 1)
- 6 instances of untyped `(as any)` type casts (lines 28, 52, 77, 96, 115, 159)

This reduced test quality and failed linting checks.

### Solution
- Removed unused `vi` import
- Replaced 6 `any` type casts with proper `React.RefObject<HTMLDivElement>` typing
- Improved type safety across all test cases:
  - Focus trap on Tab from last to first
  - Focus trap on Shift+Tab from first to last
  - Inactive focus trap state
  - Multiple focusable element types
  - Disabled elements handling
  - Hidden elements handling

### Impact  
Test code now passes strict ESLint and TypeScript linting.

---

## Files Modified
- `app/[locale]/auth/oauth/callback/page.tsx` – Added validator function
- `hooks/__tests__/use-focus-trap.test.ts` – Improved typing

## Testing Notes
- Security fix prevents open redirect attacks
- Type fixes improve test quality without behavior changes
- No breaking changes for valid paths

closes #785 
closes #779 