### PR TITLE
fix(a11y): remove unused useCallback import

### DIFF
--- a/hooks/use-focus-trap.ts
+++ b/hooks/use-focus-trap.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef } from 'react'
 
 /**
  * Gets all focusable elements within a container


### PR DESCRIPTION
## Summary

- Remove the unused `useCallback` import from `hooks/use-focus-trap.ts`
- No functional changes

## Validation

- Lint passes successfully

## Issue

- Closes #780